### PR TITLE
Fix #117: Update screenshots prevent switch without refreshing the app

### DIFF
--- a/app/src/main/java/com/mensinator/app/SettingsDialog.kt
+++ b/app/src/main/java/com/mensinator/app/SettingsDialog.kt
@@ -78,7 +78,7 @@ object ResourceMapper {
 
 
 @Composable
-fun SettingsDialog() {
+fun SettingsDialog(onSwitchProtectionScreen: (Boolean) -> Unit) {
     Log.d("SettingsDialog", "SettingsDialog recomposed")
 
     val context = LocalContext.current
@@ -331,6 +331,9 @@ fun SettingsDialog() {
                                     Switch(
                                         checked = isChecked,
                                         onCheckedChange = { newValue ->
+                                            if(setting.label == "Protect screen"){
+                                                onSwitchProtectionScreen(newValue)
+                                            }
                                             isChecked = newValue
                                             savedSettings = savedSettings.map {
                                                 if (it.key == setting.key) it.copy(value = if (newValue) "1" else "0") else it

--- a/app/src/main/java/com/mensinator/app/navigation/bottomBar.kt
+++ b/app/src/main/java/com/mensinator/app/navigation/bottomBar.kt
@@ -218,7 +218,9 @@ fun BottomBar(
             }
             composable(route = Screens.Settings.name) {
                 // here you add the page that you want to open(Settings)
-                SettingsDialog()
+                SettingsDialog(onSwitchProtectionScreen = { newValue ->
+                    onScreenProtectionChanged(newValue)
+                })
             }
         }
     }


### PR DESCRIPTION
Screen sharing will be disabled as soon as the button is switched as shown in the video


https://github.com/user-attachments/assets/55d5ebc0-99dc-4daf-8a50-9603e717b112

