### PR TITLE
Enable monochrome app icon

### DIFF
--- a/app/src/main/res/mipmap-anydpi/ic_launcher.xml
+++ b/app/src/main/res/mipmap-anydpi/ic_launcher.xml
@@ -2,4 +2,5 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@mipmap/ic_launcher_background" />
     <foreground android:drawable="@mipmap/ic_launcher_foreground" />
+    <monochrome android:drawable="@mipmap/ic_launcher_monochrome" />
 </adaptive-icon>


### PR DESCRIPTION
It's not enough to just have it somewhere, it has to be specified in the `<adaptive-icon>` tag 😊.

Before:
<img width="338" alt="Bildschirmfoto 2024-10-11 um 22 22 22" src="https://github.com/user-attachments/assets/f0a75d70-246c-4dce-bbee-6dbf88700186">

After:
<img width="336" alt="Bildschirmfoto 2024-10-11 um 22 25 00" src="https://github.com/user-attachments/assets/18e90500-7713-46af-9b2d-bb1e7a6d63c9">
