### PR TITLE
Add CI pipeline

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,22 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+      - name: Build with Gradle
+        run: chmod +x gradlew && ./gradlew build


### PR DESCRIPTION
Right now, there's no Action / Pipeline yet. There are also no other checks. Because of this, it is currently possible to merge a PR that breaks the build (see #165).

This action simply uses an ubuntu image and builds the project.