### PR TITLE
Update upload-sarif action to v3

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,7 +22,7 @@ jobs:
         run: chmod +x gradlew && ./gradlew build
 
       # Explained at https://medium.com/bumble-tech/android-lint-and-detekt-warnings-in-github-pull-requests-2880df5d32af
-      - uses: github/codeql-action/upload-sarif@v2
+      - uses: github/codeql-action/upload-sarif@v3
         if: success() || failure()
         with:
           sarif_file: app/build/reports/lint-results-debug.sarif

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,6 +10,9 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      # Required for upload-sarif task
+      security-events: write
     steps:
       - uses: actions/checkout@v4
       - name: set up JDK 17


### PR DESCRIPTION
```
    permissions:
      # required for all workflows
      security-events: write
```

https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/uploading-a-sarif-file-to-github#example-workflow-for-sarif-files-generated-outside-of-a-repository