### PR TITLE
Harmonize dialogs, general cleanup

### DIFF
--- a/app/src/main/java/com/mensinator/app/ExportImportDialog.kt
+++ b/app/src/main/java/com/mensinator/app/ExportImportDialog.kt
@@ -4,8 +4,6 @@ import android.util.Log
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
@@ -14,44 +12,51 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.mensinator.app.ui.theme.MensinatorTheme
 import java.io.File
 import java.io.FileOutputStream
-import androidx.compose.ui.res.stringResource
-
 
 @Composable
 fun ExportDialog(
     onDismissRequest: () -> Unit,
-    onExportClick: (String) -> Unit
+    onExportClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val exportImport = remember { ExportImport() }
+    val isBeingPreviewed = LocalInspectionMode.current
 
-    val exportPath = remember { mutableStateOf(exportImport.getDocumentsExportFilePath()) }
+    val exportPath = remember {
+        if (isBeingPreviewed) {
+            "/preview/path/example"
+        } else {
+            exportImport.getDocumentsExportFilePath()
+        }
+    }
 
-    val expSuccess = stringResource(id = R.string.export_success_toast, exportPath.value)
+    val expSuccess = stringResource(id = R.string.export_success_toast, exportPath)
     AlertDialog(
         onDismissRequest = onDismissRequest,
         confirmButton = {
             Button(
                 onClick = {
-                    onExportClick(exportPath.value) // Calls the exported function
+                    onExportClick(exportPath) // Calls the exported function
                     Toast.makeText(context, expSuccess, Toast.LENGTH_SHORT).show()
                     onDismissRequest()
                 },
-
-                modifier = Modifier.padding(end = 27.dp)
             ) {
                 Text(stringResource(id = R.string.export_button))
             }
         },
+        modifier = modifier,
         dismissButton = {
             Button(
                 onClick = {
                     onDismissRequest()
                 },
-                modifier = Modifier.padding(end = 30.dp)
             ) {
                 Text(stringResource(id = R.string.cancel_button))
             }
@@ -60,9 +65,7 @@ fun ExportDialog(
             Text(stringResource(id = R.string.export_data))
         },
         text = {
-            Column {
-                Text(stringResource(id = R.string.export_path_label, exportPath.value))
-            }
+            Text(stringResource(id = R.string.export_path_label, exportPath))
         }
     )
 }
@@ -70,7 +73,8 @@ fun ExportDialog(
 @Composable
 fun ImportDialog(
     onDismissRequest: () -> Unit,
-    onImportClick: (String) -> Unit
+    onImportClick: (String) -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
     val exportImport = remember { ExportImport() }
@@ -81,66 +85,79 @@ fun ImportDialog(
 
     val importLauncher =
         rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-            uri?.let {
-                val inputStream = context.contentResolver.openInputStream(it)
-                val file = File(exportImport.getDefaultImportFilePath(context))
-                val outputStream = FileOutputStream(file)
-                try {
-                    inputStream?.copyTo(outputStream)
-                    importPath.value = file.absolutePath
-                    // Call the import function
-                    onImportClick(importPath.value)
-                    // Show success toast
-                    Toast.makeText(context, impSuccess, Toast.LENGTH_SHORT).show()
-                } catch (e: Exception) {
-                    // Show error toast
-                    Toast.makeText(context, impFailure, Toast.LENGTH_SHORT).show()
-                    Log.d(
-                        "ExportImportDialog",
-                        "Failed to import file: ${e.message}, ${e.stackTraceToString()}"
-                    )
-                } finally {
-                    // Clean up
-                    inputStream?.close()
-                    outputStream.close()
-                }
-                // Dismiss the dialog after importing
-                onDismissRequest()
+            if (uri == null) return@rememberLauncherForActivityResult
+
+            val inputStream = context.contentResolver.openInputStream(uri)
+            val file = File(exportImport.getDefaultImportFilePath(context))
+            val outputStream = FileOutputStream(file)
+            try {
+                inputStream?.copyTo(outputStream)
+                importPath.value = file.absolutePath
+                // Call the import function
+                onImportClick(importPath.value)
+                // Show success toast
+                Toast.makeText(context, impSuccess, Toast.LENGTH_SHORT).show()
+            } catch (e: Exception) {
+                // Show error toast
+                Toast.makeText(context, impFailure, Toast.LENGTH_SHORT).show()
+                Log.d(
+                    "ExportImportDialog",
+                    "Failed to import file: ${e.message}, ${e.stackTraceToString()}"
+                )
+            } finally {
+                // Clean up
+                inputStream?.close()
+                outputStream.close()
             }
+            // Dismiss the dialog after importing
+            onDismissRequest()
         }
 
     AlertDialog(
         onDismissRequest = onDismissRequest,
-        dismissButton = {
-            Button(
-                onClick = {
-                    onDismissRequest()
-                },
-
-                modifier = Modifier.padding(end = 27.dp)
-            ) {
-                Text(stringResource(id = R.string.cancel_button))
-            }
-        },
         confirmButton = {
             Button(
                 onClick = {
                     importLauncher.launch("application/json")
                 },
-                modifier = Modifier.padding(end = 10.dp)
             ) {
                 Text(stringResource(id = R.string.select_file_button))
+            }
+        },
+        modifier = modifier,
+        dismissButton = {
+            Button(
+                onClick = {
+                    onDismissRequest()
+                },
+            ) {
+                Text(stringResource(id = R.string.cancel_button))
             }
         },
         title = {
             Text(stringResource(id = R.string.import_data))
         },
         text = {
-            Column {
-                Text(
-                    stringResource(R.string.select_file)
-                )
-            }
+            Text(
+                stringResource(R.string.select_file)
+            )
         }
     )
+}
+
+
+@Preview
+@Composable
+private fun ExportDialogPreview() {
+    MensinatorTheme {
+        ExportDialog(onDismissRequest = {}, onExportClick = {})
+    }
+}
+
+@Preview
+@Composable
+private fun ImportDialogPreview() {
+    MensinatorTheme {
+        ImportDialog(onDismissRequest = {}, onImportClick = {})
+    }
 }

--- a/app/src/main/java/com/mensinator/app/FAQDialog.kt
+++ b/app/src/main/java/com/mensinator/app/FAQDialog.kt
@@ -13,107 +13,20 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.res.stringResource
-
-
-
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mensinator.app.ui.theme.MensinatorTheme
 
 
 @Composable
 fun FAQDialog(
-    onDismissRequest: () -> Unit // Callback to handle the close action
+    onDismissRequest: () -> Unit, // Callback to handle the close action
+    modifier: Modifier = Modifier
 ) {
-    val scrollState = rememberScrollState()
-
     AlertDialog(
         onDismissRequest = onDismissRequest,  // Call the dismiss callback when dialog is dismissed
-        title = {
-            Text(text = stringResource(id = R.string.about_app))
-        },
-        text = {
-            Column(
-                modifier = Modifier
-                    .padding(16.dp)  // Padding around the text content
-                    .fillMaxWidth()
-                    .verticalScroll(scrollState)  // Add vertical scrolling capability
-            ) {
-                // User Manual Header
-                Text(
-                    text = stringResource(id = R.string.user_manual_header),
-                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                    color = MaterialTheme.colorScheme.primary
-                )
-                Spacer(modifier = Modifier.height(8.dp)) // Space between sections
-
-                // How to Use
-                Text(
-                    text = stringResource(id = R.string.how_to_use),
-                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
-                )
-                Text(
-                    text = stringResource(id = R.string.select_dates),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = stringResource(id = R.string.add_or_remove_dates),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = stringResource(id = R.string.symptoms),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = stringResource(id = R.string.ovulation),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = stringResource(id = R.string.statistics),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = stringResource(id = R.string.import_export),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Spacer(modifier = Modifier.height(16.dp)) // Space between sections
-                Text(
-                    text = stringResource(id = R.string.calculations),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Text(
-                    text = stringResource(id = R.string.features_coming_soon),
-                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
-                )
-                Text(
-                    text = stringResource(id = R.string.upcoming_features),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Spacer(modifier = Modifier.height(16.dp)) // Space between sections
-
-                // Our Story Header
-                Text(
-                    text = stringResource(id = R.string.our_story_header),
-                    style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
-                    color = MaterialTheme.colorScheme.primary
-                )
-                Text(
-                    text = stringResource(id = R.string.our_story),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-                Spacer(modifier = Modifier.height(16.dp)) // Space between sections
-
-                // Disclaimer Header
-                Text(
-                    text = stringResource(id = R.string.disclaimer_header),
-                    style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
-                )
-                Text(
-                    text = stringResource(id = R.string.disclaimer),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-            }
-        },
         confirmButton = {
             Button(
                 onClick = onDismissRequest  // Call the dismiss callback when the button is clicked
@@ -121,8 +34,104 @@ fun FAQDialog(
                 Text(stringResource(id = R.string.close_button))
             }
         },
-        modifier = Modifier
-            .fillMaxWidth()
-
+        modifier = modifier.fillMaxWidth(),
+        title = {
+            Text(text = stringResource(id = R.string.about_app))
+        },
+        text = {
+            FAQDialogContent()
+        },
     )
+}
+
+@Composable
+private fun FAQDialogContent() {
+    Column(
+        modifier = Modifier
+            .padding(16.dp)  // Padding around the text content
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())  // Add vertical scrolling capability
+    ) {
+        // User Manual Header
+        Text(
+            text = stringResource(id = R.string.user_manual_header),
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.primary
+        )
+        Spacer(modifier = Modifier.height(8.dp)) // Space between sections
+
+        // How to Use
+        Text(
+            text = stringResource(id = R.string.how_to_use),
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
+        )
+        Text(
+            text = stringResource(id = R.string.select_dates),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            text = stringResource(id = R.string.add_or_remove_dates),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            text = stringResource(id = R.string.symptoms),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            text = stringResource(id = R.string.ovulation),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            text = stringResource(id = R.string.statistics),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            text = stringResource(id = R.string.import_export),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Spacer(modifier = Modifier.height(16.dp)) // Space between sections
+        Text(
+            text = stringResource(id = R.string.calculations),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Text(
+            text = stringResource(id = R.string.features_coming_soon),
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
+        )
+        Text(
+            text = stringResource(id = R.string.upcoming_features),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Spacer(modifier = Modifier.height(16.dp)) // Space between sections
+
+        // Our Story Header
+        Text(
+            text = stringResource(id = R.string.our_story_header),
+            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.Bold),
+            color = MaterialTheme.colorScheme.primary
+        )
+        Text(
+            text = stringResource(id = R.string.our_story),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        Spacer(modifier = Modifier.height(16.dp)) // Space between sections
+
+        // Disclaimer Header
+        Text(
+            text = stringResource(id = R.string.disclaimer_header),
+            style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Bold)
+        )
+        Text(
+            text = stringResource(id = R.string.disclaimer),
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun FAQDialogPreview() {
+    MensinatorTheme {
+        FAQDialog(onDismissRequest = {})
+    }
 }

--- a/app/src/main/java/com/mensinator/app/MainActivity.kt
+++ b/app/src/main/java/com/mensinator/app/MainActivity.kt
@@ -1,4 +1,5 @@
 package com.mensinator.app
+
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
@@ -7,26 +8,26 @@ import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import com.mensinator.app.navigation.BottomBar
+import com.mensinator.app.navigation.MensinatorBottomBar
 import com.mensinator.app.ui.theme.MensinatorTheme
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+
         setContent {
             MensinatorTheme {
-                BottomBar {
-                    isScreenProtectionEnabled ->
+                MensinatorBottomBar { isScreenProtectionEnabled ->
                     // Sets the flags for screen protection if
                     // isScreenProtectionEnabled == true
                     // If isScreenProtectionEnabled == false it removes the flags
-                    if(isScreenProtectionEnabled){
+                    if (isScreenProtectionEnabled) {
                         window?.setFlags(
                             WindowManager.LayoutParams.FLAG_SECURE,
                             WindowManager.LayoutParams.FLAG_SECURE
                         )
-                    }else{
+                    } else {
                         window?.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
                     }
                 }

--- a/app/src/main/java/com/mensinator/app/ManageSymptomScreen.kt
+++ b/app/src/main/java/com/mensinator/app/ManageSymptomScreen.kt
@@ -99,15 +99,14 @@ fun ManageSymptomScreen(
             val symptomKey = ResourceMapper.getStringResourceId(symptom.name)
             val symptomDisplayName = symptomKey?.let { stringResource(id = it) } ?: symptom.name
             Card(
+                onClick = {
+                    symptomToRename = symptom
+                    showRenameDialog = true
+                },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 15.dp)
-                    .clickable {
-                        symptomToRename = symptom
-                        showRenameDialog = true
-                    },
+                    .padding(top = 15.dp),
                 shape = RoundedCornerShape(25.dp),
-                colors = CardDefaults.cardColors(),
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,

--- a/app/src/main/java/com/mensinator/app/ManageSymptomScreen.kt
+++ b/app/src/main/java/com/mensinator/app/ManageSymptomScreen.kt
@@ -18,8 +18,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
@@ -29,7 +27,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.getValue
@@ -54,9 +51,8 @@ import com.mensinator.app.ui.theme.isDarkMode
 
 //Maps Database keys to res/strings.xml for multilanguage support
 @Composable
-fun ManageSymptom(
+fun ManageSymptomScreen(
     showCreateSymptom: MutableState<Boolean>,
-    onSave: () -> Unit
 ) {
     val context = LocalContext.current
     val dbHelper = remember { PeriodDatabaseHelper(context) }
@@ -132,7 +128,6 @@ fun ManageSymptom(
                                     symptom.let { symptom ->
                                         savedSymptoms = savedSymptoms.filter { it.id != symptom.id }
                                         dbHelper.deleteSymptom(symptom.id)
-                                        onSave()
                                     }
                                 }
                             },
@@ -232,7 +227,6 @@ fun ManageSymptom(
                                                                 symptom.color
                                                             )
                                                         }
-                                                        onSave()
                                                     },
                                                     text = {
                                                         Box(
@@ -269,10 +263,7 @@ fun ManageSymptom(
                                     symptom.color
                                 )
                             }
-                            onSave()
                         },
-                        colors = SwitchDefaults.colors(
-                        )
                     )
                     Spacer(modifier = Modifier.weight(0.05f))
                 }
@@ -316,85 +307,15 @@ fun ManageSymptom(
 
     // Show the delete confirmation dialog
     if (showDeleteDialog) {
-        AlertDialog(
-            onDismissRequest = {
+        DeleteSymptomDialog(
+            onSave = {
+                symptomToDelete?.let { symptom ->
+                    savedSymptoms = savedSymptoms.filter { it.id != symptom.id }
+                    dbHelper.deleteSymptom(symptom.id)
+                }
                 showDeleteDialog = false
             },
-            title = {
-                Text(text = stringResource(id = R.string.delete_symptom))
-            },
-            text = {
-                Text(text = stringResource(id = R.string.delete_question))
-            },
-            confirmButton = {
-                Button(
-                    onClick = {
-                        symptomToDelete?.let { symptom ->
-                            savedSymptoms = savedSymptoms.filter { it.id != symptom.id }
-                            dbHelper.deleteSymptom(symptom.id)
-                            onSave()
-                        }
-
-                        showDeleteDialog = false
-                    },
-                    modifier = Modifier.padding(end = 27.dp)
-                ) {
-                    Text(text = stringResource(id = R.string.delete_button))
-                }
-            },
-            dismissButton = {
-                Button(
-                    onClick = {
-                        showDeleteDialog = false
-                    },
-                    modifier = Modifier.padding(end = 30.dp)
-                ) {
-                    Text(text = stringResource(id = R.string.cancel_button))
-                }
-            }
+            onCancel = { showDeleteDialog = false },
         )
     }
-}
-
-@Composable
-fun RenameSymptomDialog(
-    symptomDisplayName: String,
-    onRename: (String) -> Unit,
-    onCancel: () -> Unit
-) {
-    var newName by remember { mutableStateOf(symptomDisplayName) }
-
-    AlertDialog(
-        onDismissRequest = onCancel,
-        title = {
-            Text(text = stringResource(id = R.string.rename_symptom))
-        },
-        text = {
-            Column {
-                Spacer(modifier = Modifier.size(8.dp))
-                TextField(
-                    value = newName,
-                    onValueChange = { newName = it },
-                )
-            }
-        },
-        confirmButton = {
-            Button(
-                onClick = {
-                    onRename(newName)
-                },
-                modifier = Modifier.padding(end = 27.dp)
-            ) {
-                Text(text = stringResource(id = R.string.save_button))
-            }
-        },
-        dismissButton = {
-            Button(
-                onClick = onCancel,
-                modifier = Modifier.padding(end = 30.dp)
-            ) {
-                Text(text = stringResource(id = R.string.cancel_button))
-            }
-        }
-    )
 }

--- a/app/src/main/java/com/mensinator/app/ManageSymptomScreen.kt
+++ b/app/src/main/java/com/mensinator/app/ManageSymptomScreen.kt
@@ -25,7 +25,6 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState

--- a/app/src/main/java/com/mensinator/app/SettingsScreen.kt
+++ b/app/src/main/java/com/mensinator/app/SettingsScreen.kt
@@ -77,7 +77,7 @@ object ResourceMapper {
 
 
 @Composable
-fun SettingsDialog(onSwitchProtectionScreen: (Boolean) -> Unit) {
+fun SettingsScreen(onSwitchProtectionScreen: (Boolean) -> Unit) {
     Log.d("SettingsDialog", "SettingsDialog recomposed")
 
     val context = LocalContext.current

--- a/app/src/main/java/com/mensinator/app/SettingsScreen.kt
+++ b/app/src/main/java/com/mensinator/app/SettingsScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.core.app.NotificationManagerCompat
 import com.mensinator.app.data.DataSource
 import com.mensinator.app.ui.theme.isDarkMode
-import androidx.compose.ui.platform.LocalConfiguration
 
 //Maps Database keys to res/strings.xml for multilanguage support
 object ResourceMapper {
@@ -91,9 +90,6 @@ fun SettingsScreen(onSwitchProtectionScreen: (Boolean) -> Unit) {
     var exportImportDialog by remember { mutableStateOf(false) }
     var showImportDialog by remember { mutableStateOf(false) }
     var showFAQDialog by remember { mutableStateOf(false) }
-
-    val screenHeight = LocalConfiguration.current.screenHeightDp.dp
-    val menuHeight = screenHeight * 0.8f // 80% of the screen height
 
     val predefinedReminders = (0..12).map { it.toString() }
 

--- a/app/src/main/java/com/mensinator/app/StatisticsScreen.kt
+++ b/app/src/main/java/com/mensinator/app/StatisticsScreen.kt
@@ -22,7 +22,7 @@ import androidx.compose.ui.text.font.FontWeight
 import java.time.LocalDate
 
 @Composable
-fun StatisticsDialog(
+fun StatisticsScreen(
 ) {
     val context = LocalContext.current
     val dbHelper = remember { PeriodDatabaseHelper(context) }

--- a/app/src/main/java/com/mensinator/app/SymptomDialogs.kt
+++ b/app/src/main/java/com/mensinator/app/SymptomDialogs.kt
@@ -10,9 +10,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import java.time.LocalDate
 import androidx.compose.ui.res.stringResource
-
-
-
+import androidx.compose.ui.tooling.preview.Preview
+import com.mensinator.app.ui.theme.MensinatorTheme
 
 
 @Composable
@@ -21,7 +20,8 @@ fun SymptomsDialog(
     symptoms: List<Symptom>,
     dbHelper: PeriodDatabaseHelper,
     onSave: (List<Symptom>) -> Unit,
-    onCancel: () -> Unit
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     var selectedSymptoms by remember { mutableStateOf(emptySet<Symptom>()) }
 
@@ -32,6 +32,27 @@ fun SymptomsDialog(
 
     AlertDialog(
         onDismissRequest = { onCancel() },
+        confirmButton = {
+            Button(
+                onClick = {
+                    onSave(selectedSymptoms.toList())
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = stringResource(id = R.string.save_symptoms_button))
+            }
+        },
+        modifier = modifier,
+        dismissButton = {
+            Button(
+                onClick = {
+                    onCancel()
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = stringResource(id = R.string.cancel_button))
+            }
+        },
         title = {
             Text(text = stringResource(id = R.string.symptoms_dialog_title, date))
         },
@@ -72,26 +93,6 @@ fun SymptomsDialog(
 //                }
             }
         },
-        confirmButton = {
-            Button(
-                onClick = {
-                    onSave(selectedSymptoms.toList())
-                },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(text = stringResource(id = R.string.save_symptoms_button))
-            }
-        },
-        dismissButton = {
-            Button(
-                onClick = {
-                    onCancel()
-                },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(text = stringResource(id = R.string.cancel_button))
-            }
-        }
     )
 }
 
@@ -100,13 +101,31 @@ fun SymptomsDialog(
 fun CreateNewSymptomDialog(
     newSymptom: String,
     onSave: (String) -> Unit,
-    onCancel: () -> Unit
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     var symptomName by remember { mutableStateOf(newSymptom) }
     //val symptomKey = ResourceMapper.getStringResourceId(symptomName)
 
     AlertDialog(
-        onDismissRequest = { onCancel() },
+        onDismissRequest = onCancel,
+        confirmButton = {
+            Button(
+                onClick = {
+                    onSave(symptomName)
+                },
+            ) {
+                Text(stringResource(id = R.string.save_button))
+            }
+        },
+        modifier = modifier,
+        dismissButton = {
+            Button(
+                onClick = onCancel,
+            ) {
+                Text(stringResource(id = R.string.cancel_button))
+            }
+        },
         title = {
             Text(text = stringResource(id = R.string.create_new_symptom_dialog_title))
         },
@@ -118,25 +137,116 @@ fun CreateNewSymptomDialog(
                 label = { Text(stringResource(R.string.symptom_name_label)) }
             )
         },
+    )
+}
+
+@Composable
+fun RenameSymptomDialog(
+    symptomDisplayName: String,
+    onRename: (String) -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var newName by remember { mutableStateOf(symptomDisplayName) }
+
+    AlertDialog(
+        onDismissRequest = onCancel,
         confirmButton = {
             Button(
                 onClick = {
-                    onSave(symptomName)
+                    onRename(newName)
                 },
-                modifier = Modifier.padding(end = 27.dp)
             ) {
-                Text(stringResource(id = R.string.save_button))
+                Text(text = stringResource(id = R.string.save_button))
             }
         },
+        modifier = modifier,
         dismissButton = {
             Button(
-                onClick = {
-                    onCancel()
-                },
-                modifier = Modifier.padding(end = 30.dp)
+                onClick = onCancel,
             ) {
-                Text(stringResource(id = R.string.cancel_button))
+                Text(text = stringResource(id = R.string.cancel_button))
             }
-        }
+        },
+        title = {
+            Text(text = stringResource(id = R.string.rename_symptom))
+        },
+        text = {
+            Column {
+                TextField(
+                    value = newName,
+                    onValueChange = { newName = it },
+                    label = { Text(stringResource(R.string.symptom_name_label)) }
+                )
+            }
+        },
+
     )
+}
+
+@Composable
+fun DeleteSymptomDialog(
+    onSave: () -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    AlertDialog(
+        onDismissRequest = onCancel,
+        confirmButton = {
+            Button(
+                onClick = onSave,
+            ) {
+                Text(text = stringResource(id = R.string.delete_button))
+            }
+        },
+        modifier = modifier,
+        dismissButton = {
+            Button(
+                onClick = onCancel,
+            ) {
+                Text(text = stringResource(id = R.string.cancel_button))
+            }
+        },
+        title = {
+            Text(text = stringResource(id = R.string.delete_symptom))
+        },
+        text = {
+            Text(text = stringResource(id = R.string.delete_question))
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun CreateNewSymptomDialogPreview() {
+    MensinatorTheme {
+        CreateNewSymptomDialog(
+            newSymptom = "preview",
+            onSave = {},
+            onCancel = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun RenameSymptomDialogPreview() {
+    MensinatorTheme {
+        RenameSymptomDialog(
+            symptomDisplayName = "preview",
+            onRename = {},
+            onCancel = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun DeleteSymptomDialogPreview() {
+    MensinatorTheme {
+        DeleteSymptomDialog(
+            onSave = {},
+            onCancel = {}
+        )
+    }
 }

--- a/app/src/main/java/com/mensinator/app/navigation/BottomBar.kt
+++ b/app/src/main/java/com/mensinator/app/navigation/BottomBar.kt
@@ -34,11 +34,11 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.mensinator.app.CalendarScreen
-import com.mensinator.app.ManageSymptom
+import com.mensinator.app.ManageSymptomScreen
 import com.mensinator.app.PeriodDatabaseHelper
 import com.mensinator.app.R
-import com.mensinator.app.SettingsDialog
-import com.mensinator.app.StatisticsDialog
+import com.mensinator.app.SettingsScreen
+import com.mensinator.app.StatisticsScreen
 
 enum class Screens {
     Calendar,
@@ -48,7 +48,7 @@ enum class Screens {
 }
 
 @Composable
-fun BottomBar(
+fun MensinatorBottomBar(
     navController: NavHostController = rememberNavController(),
     onScreenProtectionChanged: (Boolean) -> Unit?,
 ) {
@@ -205,7 +205,7 @@ fun BottomBar(
             }
             composable(route = Screens.Statistic.name) {
                 // here you add the page that you want to open(Statistic)
-                StatisticsDialog(
+                StatisticsScreen(
 //                    nextPeriodStart = GlobalState.nextPeriodStartCalculated,
 //                    follicleGrowthDays = GlobalState.follicleGrowthDays,
 //                    nextPredictedOvulation = GlobalState.nextOvulationCalculated,
@@ -213,12 +213,11 @@ fun BottomBar(
             }
             composable(route = Screens.Symptoms.name) {
                 // here you add the page that you want to open(Symptoms)
-                ManageSymptom(showCreateSymptom) {
-                }
+                ManageSymptomScreen(showCreateSymptom)
             }
             composable(route = Screens.Settings.name) {
                 // here you add the page that you want to open(Settings)
-                SettingsDialog(onSwitchProtectionScreen = { newValue ->
+                SettingsScreen(onSwitchProtectionScreen = { newValue ->
                     onScreenProtectionChanged(newValue)
                 })
             }


### PR DESCRIPTION
Fixes #120

* Hardcoded paddings inside the dialogs got removed
* Add `modifier: Modifier = Modifier` to public composables
* Don't wrap `Text` in `Column` if not necessary (inside `AlertDialog`)
* Early abort method to avoid indentation levels
* Add compose previews where possible (when dbHelper is used, it won't work...)
* Use `Card` with `onClick` and not `Modifier.clickable()`, else the ripple animation is wrong

Screenshots:

![studio64_DL0tBnUdfA](https://github.com/user-attachments/assets/9c2028f9-c1b9-408d-b6e8-75123578813e)
![studio64_gns9CPPfZb](https://github.com/user-attachments/assets/4d9dd601-9caa-43a6-aa75-cc84ff5cad05)
![studio64_x6R4lhZTAK](https://github.com/user-attachments/assets/ba14edb1-0ffe-45ba-a0e2-696863d1e18f)
