### PR TITLE
Improve package structure, refactor Manage Symptoms Screen

### DIFF
--- a/app/src/main/java/com/mensinator/app/App.kt
+++ b/app/src/main/java/com/mensinator/app/App.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import com.mensinator.app.business.*
 import com.mensinator.app.settings.SettingsViewModel
 import com.mensinator.app.statistics.StatisticsViewModel
+import com.mensinator.app.symptoms.ManageSymptomsViewModel
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
@@ -23,6 +24,7 @@ class App : Application() {
         singleOf(::ExportImport) { bind<IExportImport>() }
         singleOf(::NotificationScheduler) { bind<INotificationScheduler>() }
 
+        viewModel { ManageSymptomsViewModel(get(), get()) }
         viewModel { SettingsViewModel(get(), get(), get()) }
         viewModel { StatisticsViewModel(get(), get(), get(), get(), get()) }
     }

--- a/app/src/main/java/com/mensinator/app/App.kt
+++ b/app/src/main/java/com/mensinator/app/App.kt
@@ -24,7 +24,7 @@ class App : Application() {
         singleOf(::ExportImport) { bind<IExportImport>() }
         singleOf(::NotificationScheduler) { bind<INotificationScheduler>() }
 
-        viewModel { ManageSymptomsViewModel(get(), get()) }
+        viewModel { ManageSymptomsViewModel(get()) }
         viewModel { SettingsViewModel(get(), get(), get()) }
         viewModel { StatisticsViewModel(get(), get(), get(), get(), get()) }
     }

--- a/app/src/main/java/com/mensinator/app/App.kt
+++ b/app/src/main/java/com/mensinator/app/App.kt
@@ -1,6 +1,7 @@
 package com.mensinator.app
 
 import android.app.Application
+import com.mensinator.app.business.*
 import com.mensinator.app.settings.SettingsViewModel
 import com.mensinator.app.statistics.StatisticsViewModel
 import org.koin.android.ext.koin.androidContext

--- a/app/src/main/java/com/mensinator/app/MainActivity.kt
+++ b/app/src/main/java/com/mensinator/app/MainActivity.kt
@@ -8,7 +8,7 @@ import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import com.mensinator.app.navigation.MensinatorApp
+import com.mensinator.app.ui.navigation.MensinatorApp
 import com.mensinator.app.ui.theme.MensinatorTheme
 
 class MainActivity : AppCompatActivity() {

--- a/app/src/main/java/com/mensinator/app/business/CalculationsHelper.kt
+++ b/app/src/main/java/com/mensinator/app/business/CalculationsHelper.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 import android.util.Log
 import com.mensinator.app.extensions.roundToTwoDecimalPoints

--- a/app/src/main/java/com/mensinator/app/business/DatabaseUtils.kt
+++ b/app/src/main/java/com/mensinator/app/business/DatabaseUtils.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 import android.database.sqlite.SQLiteDatabase
 

--- a/app/src/main/java/com/mensinator/app/business/ExportImport.kt
+++ b/app/src/main/java/com/mensinator/app/business/ExportImport.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 import android.content.ContentValues
 import android.content.Context

--- a/app/src/main/java/com/mensinator/app/business/ICalculationsHelper.kt
+++ b/app/src/main/java/com/mensinator/app/business/ICalculationsHelper.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 import java.time.LocalDate
 

--- a/app/src/main/java/com/mensinator/app/business/IExportImport.kt
+++ b/app/src/main/java/com/mensinator/app/business/IExportImport.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 interface IExportImport {
     fun getDocumentsExportFilePath(): String

--- a/app/src/main/java/com/mensinator/app/business/INotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/INotificationScheduler.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 import java.time.LocalDate
 

--- a/app/src/main/java/com/mensinator/app/business/IOvulationPrediction.kt
+++ b/app/src/main/java/com/mensinator/app/business/IOvulationPrediction.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 import java.time.LocalDate
 

--- a/app/src/main/java/com/mensinator/app/business/IPeriodDatabaseHelper.kt
+++ b/app/src/main/java/com/mensinator/app/business/IPeriodDatabaseHelper.kt
@@ -1,7 +1,9 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 import android.database.sqlite.SQLiteDatabase
 import androidx.annotation.WorkerThread
+import com.mensinator.app.data.Symptom
+import com.mensinator.app.data.Setting
 import java.time.LocalDate
 
 interface IPeriodDatabaseHelper {
@@ -39,7 +41,7 @@ interface IPeriodDatabaseHelper {
     fun updateSymptomDate(dates: List<LocalDate>, symptomId: List<Int>)
 
     // This function is used to get symptoms for a given date
-    fun getSymptomsFromDate(date: LocalDate): List<Int>
+    fun getActiveSymptomIdsForDate(date: LocalDate): List<Int>
 
     fun getSymptomColorForDate(date: LocalDate): List<String>
 

--- a/app/src/main/java/com/mensinator/app/business/IPeriodPrediction.kt
+++ b/app/src/main/java/com/mensinator/app/business/IPeriodPrediction.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 import java.time.LocalDate
 

--- a/app/src/main/java/com/mensinator/app/business/NotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/NotificationScheduler.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 
 import android.app.AlarmManager
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import androidx.core.app.NotificationManagerCompat
+import com.mensinator.app.NotificationReceiver
 import java.time.LocalDate
 import java.time.ZoneId
 

--- a/app/src/main/java/com/mensinator/app/business/OvulationPrediction.kt
+++ b/app/src/main/java/com/mensinator/app/business/OvulationPrediction.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 import android.util.Log
 import java.time.LocalDate

--- a/app/src/main/java/com/mensinator/app/business/PeriodDatabaseHelper.kt
+++ b/app/src/main/java/com/mensinator/app/business/PeriodDatabaseHelper.kt
@@ -101,7 +101,6 @@ class PeriodDatabaseHelper(context: Context) :
         if (rowsUpdated == 0) {
             db.insert(TABLE_PERIODS, null, values)
         }
-        //db.close()
     }
 
     override fun getPeriodDatesForMonth(year: Int, month: Int): Map<LocalDate, Int> {
@@ -143,7 +142,6 @@ class PeriodDatabaseHelper(context: Context) :
             Log.e(TAG, "Cursor is null while querying for dates")
         }
 
-        //db.close()
         return dates
     }
 
@@ -156,7 +154,6 @@ class PeriodDatabaseHelper(context: Context) :
             count = cursor.getInt(0)
         }
         cursor.close()
-        //db.close()
         return count
     }
 
@@ -170,7 +167,6 @@ class PeriodDatabaseHelper(context: Context) :
         } else {
             Log.d(TAG, "No date $date found in $TABLE_PERIODS to remove")
         }
-        //db.close()
     }
 
     override fun getAllSymptoms(): List<Symptom> {
@@ -194,8 +190,6 @@ class PeriodDatabaseHelper(context: Context) :
 
         }
         cursor.close()
-        //db.close()
-
         return symptoms
     }
 
@@ -208,7 +202,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
         // Insert the new symptom into the symptoms table
         db.insert(TABLE_SYMPTOMS, null, values)
-        //db.close()  // Close the database connection to free up resources
     }
 
     override fun getSymptomDatesForMonth(year: Int, month: Int): Set<LocalDate> {
@@ -250,7 +243,6 @@ class PeriodDatabaseHelper(context: Context) :
             Log.e(TAG, "Error querying for symptom dates", e)
         } finally {
             cursor.close()
-            //db.close()
         }
 
         return dates
@@ -297,7 +289,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         // Close the database connection
-        //db.close()
     }
 
     override fun getActiveSymptomIdsForDate(date: LocalDate): List<Int> {
@@ -321,7 +312,6 @@ class PeriodDatabaseHelper(context: Context) :
             }
         }
 
-        //db.close()
         return symptoms
     }
 
@@ -346,8 +336,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        //db.close()
-
         return symptomColors
     }
 
@@ -375,7 +363,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
         val rowsUpdated =
             db.update(TABLE_APP_SETTINGS, contentValues, "$COLUMN_SETTING_KEY = ?", arrayOf(key))
-        //db.close()
         return rowsUpdated > 0
     }
 
@@ -402,7 +389,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        //db.close()
         return setting
     }
 
@@ -436,7 +422,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        //db.close()
     }
 
     override fun getOvulationDatesForMonth(year: Int, month: Int): Set<LocalDate> {
@@ -474,7 +459,6 @@ class PeriodDatabaseHelper(context: Context) :
             Log.e("TAG", "Error querying for ovulation dates", e)
         } finally {
             cursor.close()
-            //db.close()
         }
 
         return dates
@@ -489,7 +473,6 @@ class PeriodDatabaseHelper(context: Context) :
             count = cursor.getInt(0)
         }
         cursor.close()
-        //db.close()
         return count
     }
 
@@ -545,7 +528,6 @@ class PeriodDatabaseHelper(context: Context) :
             Log.e(TAG, "Cursor is null while querying for periodId")
         }
 
-        //db.close()
         return periodId
     }
 
@@ -576,8 +558,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        //db.close()
-
         return firstLatestDate
     }
 
@@ -596,7 +576,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        //db.close()
         return oldestPeriodDate
     }
 
@@ -615,7 +594,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        //db.close()
         return newestOvulationDate
     }
 
@@ -644,8 +622,6 @@ class PeriodDatabaseHelper(context: Context) :
         if (rowsAffected == 0) {
             throw IllegalStateException("No symptom found with ID: $id")
         }
-
-        //db.close()
     }
 
     // This function is used to get the latest X ovulation dates where they are followed by a period
@@ -674,7 +650,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        //db.close()
         return ovulationDates
     }
 
@@ -693,7 +668,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        //db.close()
         return ovulationDate
     }
 
@@ -726,8 +700,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        //db.close()
-
         return dateList
     }
 
@@ -751,8 +723,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        //db.close()
-
         return firstNextDate
     }
 
@@ -768,7 +738,6 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        //db.close()
         return count
     }
 
@@ -787,7 +756,6 @@ class PeriodDatabaseHelper(context: Context) :
             } while (cursor.moveToNext())
         }
         cursor.close()
-        //db.close()
         return ovulationDates
     }
 
@@ -802,7 +770,6 @@ class PeriodDatabaseHelper(context: Context) :
         } else {
             Log.d(TAG, "No symptoms to delete")
         }
-        //db.close()
     }
 
     override fun getDBVersion(): String {
@@ -830,7 +797,6 @@ class PeriodDatabaseHelper(context: Context) :
             return LocalDate.parse(dateString)
         }
         cursor.close()
-        //db.close()
         return latestPeriodStart
     }
 }

--- a/app/src/main/java/com/mensinator/app/business/PeriodDatabaseHelper.kt
+++ b/app/src/main/java/com/mensinator/app/business/PeriodDatabaseHelper.kt
@@ -1,10 +1,12 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 import android.content.ContentValues
 import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import android.util.Log
+import com.mensinator.app.data.Symptom
+import com.mensinator.app.data.Setting
 import java.time.LocalDate
 
 /*
@@ -298,7 +300,7 @@ class PeriodDatabaseHelper(context: Context) :
         db.close()
     }
 
-    override fun getSymptomsFromDate(date: LocalDate): List<Int> {
+    override fun getActiveSymptomIdsForDate(date: LocalDate): List<Int> {
         val db = readableDatabase
         val symptoms = mutableListOf<Int>()
 

--- a/app/src/main/java/com/mensinator/app/business/PeriodDatabaseHelper.kt
+++ b/app/src/main/java/com/mensinator/app/business/PeriodDatabaseHelper.kt
@@ -101,7 +101,7 @@ class PeriodDatabaseHelper(context: Context) :
         if (rowsUpdated == 0) {
             db.insert(TABLE_PERIODS, null, values)
         }
-        db.close()
+        //db.close()
     }
 
     override fun getPeriodDatesForMonth(year: Int, month: Int): Map<LocalDate, Int> {
@@ -143,7 +143,7 @@ class PeriodDatabaseHelper(context: Context) :
             Log.e(TAG, "Cursor is null while querying for dates")
         }
 
-        db.close()
+        //db.close()
         return dates
     }
 
@@ -156,7 +156,7 @@ class PeriodDatabaseHelper(context: Context) :
             count = cursor.getInt(0)
         }
         cursor.close()
-        db.close()
+        //db.close()
         return count
     }
 
@@ -170,7 +170,7 @@ class PeriodDatabaseHelper(context: Context) :
         } else {
             Log.d(TAG, "No date $date found in $TABLE_PERIODS to remove")
         }
-        db.close()
+        //db.close()
     }
 
     override fun getAllSymptoms(): List<Symptom> {
@@ -194,7 +194,7 @@ class PeriodDatabaseHelper(context: Context) :
 
         }
         cursor.close()
-        db.close()
+        //db.close()
 
         return symptoms
     }
@@ -208,7 +208,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
         // Insert the new symptom into the symptoms table
         db.insert(TABLE_SYMPTOMS, null, values)
-        db.close()  // Close the database connection to free up resources
+        //db.close()  // Close the database connection to free up resources
     }
 
     override fun getSymptomDatesForMonth(year: Int, month: Int): Set<LocalDate> {
@@ -250,7 +250,7 @@ class PeriodDatabaseHelper(context: Context) :
             Log.e(TAG, "Error querying for symptom dates", e)
         } finally {
             cursor.close()
-            db.close()
+            //db.close()
         }
 
         return dates
@@ -297,7 +297,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         // Close the database connection
-        db.close()
+        //db.close()
     }
 
     override fun getActiveSymptomIdsForDate(date: LocalDate): List<Int> {
@@ -321,7 +321,7 @@ class PeriodDatabaseHelper(context: Context) :
             }
         }
 
-        db.close()
+        //db.close()
         return symptoms
     }
 
@@ -346,7 +346,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        db.close()
+        //db.close()
 
         return symptomColors
     }
@@ -375,7 +375,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
         val rowsUpdated =
             db.update(TABLE_APP_SETTINGS, contentValues, "$COLUMN_SETTING_KEY = ?", arrayOf(key))
-        db.close()
+        //db.close()
         return rowsUpdated > 0
     }
 
@@ -402,7 +402,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        db.close()
+        //db.close()
         return setting
     }
 
@@ -436,7 +436,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        db.close()
+        //db.close()
     }
 
     override fun getOvulationDatesForMonth(year: Int, month: Int): Set<LocalDate> {
@@ -474,7 +474,7 @@ class PeriodDatabaseHelper(context: Context) :
             Log.e("TAG", "Error querying for ovulation dates", e)
         } finally {
             cursor.close()
-            db.close()
+            //db.close()
         }
 
         return dates
@@ -489,7 +489,7 @@ class PeriodDatabaseHelper(context: Context) :
             count = cursor.getInt(0)
         }
         cursor.close()
-        db.close()
+        //db.close()
         return count
     }
 
@@ -545,7 +545,7 @@ class PeriodDatabaseHelper(context: Context) :
             Log.e(TAG, "Cursor is null while querying for periodId")
         }
 
-        db.close()
+        //db.close()
         return periodId
     }
 
@@ -576,7 +576,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        db.close()
+        //db.close()
 
         return firstLatestDate
     }
@@ -596,7 +596,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        db.close()
+        //db.close()
         return oldestPeriodDate
     }
 
@@ -615,7 +615,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        db.close()
+        //db.close()
         return newestOvulationDate
     }
 
@@ -645,7 +645,7 @@ class PeriodDatabaseHelper(context: Context) :
             throw IllegalStateException("No symptom found with ID: $id")
         }
 
-        db.close()
+        //db.close()
     }
 
     // This function is used to get the latest X ovulation dates where they are followed by a period
@@ -674,7 +674,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        db.close()
+        //db.close()
         return ovulationDates
     }
 
@@ -693,7 +693,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        db.close()
+        //db.close()
         return ovulationDate
     }
 
@@ -726,7 +726,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        db.close()
+        //db.close()
 
         return dateList
     }
@@ -751,7 +751,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        db.close()
+        //db.close()
 
         return firstNextDate
     }
@@ -768,7 +768,7 @@ class PeriodDatabaseHelper(context: Context) :
         }
 
         cursor.close()
-        db.close()
+        //db.close()
         return count
     }
 
@@ -787,7 +787,7 @@ class PeriodDatabaseHelper(context: Context) :
             } while (cursor.moveToNext())
         }
         cursor.close()
-        db.close()
+        //db.close()
         return ovulationDates
     }
 
@@ -802,7 +802,7 @@ class PeriodDatabaseHelper(context: Context) :
         } else {
             Log.d(TAG, "No symptoms to delete")
         }
-        db.close()
+        //db.close()
     }
 
     override fun getDBVersion(): String {
@@ -830,7 +830,7 @@ class PeriodDatabaseHelper(context: Context) :
             return LocalDate.parse(dateString)
         }
         cursor.close()
-        db.close()
+        //db.close()
         return latestPeriodStart
     }
 }

--- a/app/src/main/java/com/mensinator/app/business/PeriodPrediction.kt
+++ b/app/src/main/java/com/mensinator/app/business/PeriodPrediction.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.business
 
 import java.time.LocalDate
 

--- a/app/src/main/java/com/mensinator/app/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/mensinator/app/calendar/CalendarScreen.kt
@@ -40,7 +40,7 @@ import com.mensinator.app.business.IPeriodDatabaseHelper
 import com.mensinator.app.business.IPeriodPrediction
 import com.mensinator.app.data.ColorSource
 import com.mensinator.app.data.isActive
-import com.mensinator.app.navigation.displayCutoutExcludingStatusBarsPadding
+import com.mensinator.app.ui.navigation.displayCutoutExcludingStatusBarsPadding
 import com.mensinator.app.settings.ResourceMapper
 import com.mensinator.app.settings.StringSetting
 import com.mensinator.app.ui.theme.isDarkMode

--- a/app/src/main/java/com/mensinator/app/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/mensinator/app/calendar/CalendarScreen.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.calendar
 
 
 import android.content.Context
@@ -32,7 +32,14 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.mensinator.app.R
+import com.mensinator.app.data.Symptom
+import com.mensinator.app.business.INotificationScheduler
+import com.mensinator.app.business.IOvulationPrediction
+import com.mensinator.app.business.IPeriodDatabaseHelper
+import com.mensinator.app.business.IPeriodPrediction
 import com.mensinator.app.data.ColorSource
+import com.mensinator.app.data.isActive
 import com.mensinator.app.navigation.displayCutoutExcludingStatusBarsPadding
 import com.mensinator.app.settings.ResourceMapper
 import com.mensinator.app.settings.StringSetting
@@ -630,11 +637,12 @@ fun CalendarScreen(modifier: Modifier) {
         // Show the SymptomsDialog
         if (showSymptomsDialog && selectedDates.value.isNotEmpty()) {
             val activeSymptoms = dbHelper.getAllSymptoms().filter { it.isActive }
+            val date = selectedDates.value.last()
 
-            SymptomsDialog(
-                date = selectedDates.value.last(),  // Pass the last selected date
+            EditSymptomsForDaysDialog(
+                date = date,  // Pass the last selected date
                 symptoms = activeSymptoms,
-                dbHelper = dbHelper,
+                currentlyActiveSymptomIds = dbHelper.getActiveSymptomIdsForDate(date).toSet(),
                 onSave = { selectedSymptoms ->
                     val selectedSymptomIds = selectedSymptoms.map { it.id }
                     val datesToUpdate = selectedDates.value.toList()

--- a/app/src/main/java/com/mensinator/app/calendar/SymptomDialogs.kt
+++ b/app/src/main/java/com/mensinator/app/calendar/SymptomDialogs.kt
@@ -12,7 +12,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import com.mensinator.app.settings.ResourceMapper
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.mensinator.app.R
 import com.mensinator.app.data.Symptom
 import com.mensinator.app.ui.theme.MensinatorTheme
@@ -85,15 +84,6 @@ fun EditSymptomsForDaysDialog(
                         Text(text = symptomDisplayName)
                     }
                 }
-//                Spacer(modifier = Modifier.height(16.dp))
-//                Button(
-//                    onClick = {
-//                        onCreateNewSymptom()
-//                    },
-//                    modifier = Modifier.fillMaxWidth()
-//                ) {
-//                    Text(text = stringResource(id = R.string.create_new_symptom_button))
-//                }
             }
         },
     )

--- a/app/src/main/java/com/mensinator/app/calendar/SymptomDialogs.kt
+++ b/app/src/main/java/com/mensinator/app/calendar/SymptomDialogs.kt
@@ -1,0 +1,137 @@
+package com.mensinator.app.calendar
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.mensinator.app.settings.ResourceMapper
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.mensinator.app.R
+import com.mensinator.app.data.Symptom
+import com.mensinator.app.ui.theme.MensinatorTheme
+import java.time.LocalDate
+
+@Composable
+fun EditSymptomsForDaysDialog(
+    date: LocalDate,
+    symptoms: List<Symptom>,
+    currentlyActiveSymptomIds: Set<Int>,
+    onSave: (List<Symptom>) -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var selectedSymptoms by remember {
+        mutableStateOf(
+            symptoms.filter { it.id in currentlyActiveSymptomIds }.toSet()
+        )
+    }
+
+    AlertDialog(
+        onDismissRequest = { onCancel() },
+        confirmButton = {
+            Button(
+                onClick = {
+                    onSave(selectedSymptoms.toList())
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = stringResource(id = R.string.save_symptoms_button))
+            }
+        },
+        modifier = modifier,
+        dismissButton = {
+            Button(
+                onClick = {
+                    onCancel()
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(text = stringResource(id = R.string.cancel_button))
+            }
+        },
+        title = {
+            Text(text = stringResource(id = R.string.symptoms_dialog_title, date))
+        },
+        text = {
+            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
+                symptoms.forEach { symptom ->
+                    val symptomKey = ResourceMapper.getStringResourceId(symptom.name)
+                    val symptomDisplayName = symptomKey?.let { stringResource(id = it) } ?: symptom.name
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(8.dp)
+                            .clickable {
+                                selectedSymptoms = if (selectedSymptoms.contains(symptom)) {
+                                    selectedSymptoms - symptom
+                                } else {
+                                    selectedSymptoms + symptom
+                                }
+                            },
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Checkbox(
+                            checked = selectedSymptoms.contains(symptom),
+                            onCheckedChange = null
+                        )
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(text = symptomDisplayName)
+                    }
+                }
+//                Spacer(modifier = Modifier.height(16.dp))
+//                Button(
+//                    onClick = {
+//                        onCreateNewSymptom()
+//                    },
+//                    modifier = Modifier.fillMaxWidth()
+//                ) {
+//                    Text(text = stringResource(id = R.string.create_new_symptom_button))
+//                }
+            }
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun EditSymptomsForDaysDialog_OneDayPreview() {
+    val symptoms = listOf(
+        Symptom(1, "Light", 0, ""),
+        Symptom(2, "Medium", 1, ""),
+    )
+    MensinatorTheme {
+        EditSymptomsForDaysDialog(
+            date = LocalDate.now(),
+            symptoms = symptoms,
+            currentlyActiveSymptomIds = setOf(2),
+            onSave = {},
+            onCancel = { },
+        )
+    }
+}
+
+// TODO: Fix within https://github.com/EmmaTellblom/Mensinator/issues/203
+@Preview
+@Composable
+private fun EditSymptomsForDaysDialog_MultipleDaysPreview() {
+    val symptoms = listOf(
+        Symptom(1, "Light", 0, ""),
+        Symptom(2, "Medium", 1, ""),
+    )
+    MensinatorTheme {
+        EditSymptomsForDaysDialog(
+            date = LocalDate.now(),
+            symptoms = symptoms,
+            currentlyActiveSymptomIds = setOf(2),
+            onSave = {},
+            onCancel = { },
+        )
+    }
+}

--- a/app/src/main/java/com/mensinator/app/data/Setting.kt
+++ b/app/src/main/java/com/mensinator/app/data/Setting.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.data
 
 data class Setting(
     val key: String,

--- a/app/src/main/java/com/mensinator/app/data/Symptom.kt
+++ b/app/src/main/java/com/mensinator/app/data/Symptom.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.data
 
 data class Symptom(
     val id: Int,

--- a/app/src/main/java/com/mensinator/app/navigation/MensinatorApp.kt
+++ b/app/src/main/java/com/mensinator/app/navigation/MensinatorApp.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
@@ -66,30 +66,12 @@ fun MensinatorApp(
 //    var nextOvulationCalculated by remember { mutableStateOf("Not enough data") }
 //    var follicleGrowthDays by remember { mutableStateOf("0") }
 
-    val showCreateSymptom = rememberSaveable { mutableStateOf(false) }
-
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentScreen = Screen.valueOf(
         backStackEntry?.destination?.route ?: Screen.Calendar.name
     )
 
     Scaffold(
-        floatingActionButton = {
-            if (currentScreen == Screen.Symptoms) {
-                FloatingActionButton(
-                    onClick = { showCreateSymptom.value = true },
-                    shape = CircleShape,
-                    modifier = Modifier
-                        .displayCutoutPadding()
-                        .padding(5.dp)
-                ) {
-                    Icon(
-                        imageVector = Icons.Default.Add,
-                        contentDescription = stringResource(R.string.delete_button)
-                    )
-                }
-            }
-        },
         bottomBar = {
             val barItems = listOf(
                 BarItem(
@@ -164,12 +146,31 @@ fun MensinatorApp(
                 }
             }
             composable(route = Screen.Symptoms.name) {
+                // Adapted from https://stackoverflow.com/a/71191082/3991578
+                // Needed so that the action button can cause the dialog to be shown
+                val (fabOnClick, setFabOnClick) = remember { mutableStateOf<(() -> Unit)?>(null) }
                 Scaffold(
+                    floatingActionButton = {
+                        if (currentScreen == Screen.Symptoms) {
+                            FloatingActionButton(
+                                onClick = { fabOnClick?.invoke() },
+                                shape = CircleShape,
+                                modifier = Modifier
+                                    .displayCutoutPadding()
+                                    .padding(5.dp)
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Add,
+                                    contentDescription = stringResource(R.string.delete_button)
+                                )
+                            }
+                        }
+                    },
                     topBar = { MensinatorTopBar(currentScreen) }
                 ) { topBarPadding ->
                     ManageSymptomScreen(
-                        showCreateSymptom,
-                        modifier = Modifier.padding(topBarPadding)
+                        modifier = Modifier.padding(topBarPadding),
+                        setFabOnClick = setFabOnClick
                     )
                 }
             }

--- a/app/src/main/java/com/mensinator/app/navigation/MensinatorApp.kt
+++ b/app/src/main/java/com/mensinator/app/navigation/MensinatorApp.kt
@@ -134,14 +134,16 @@ fun MensinatorApp(
         ) {//create a new file for every page and pass it inside the composable
             composable(route = Screen.Calendar.name) {
                 Scaffold(
-                    topBar = { MensinatorTopBar(currentScreen) }
+                    topBar = { MensinatorTopBar(currentScreen) },
+                    contentWindowInsets = WindowInsets(0.dp),
                 ) { topBarPadding ->
                     CalendarScreen(modifier = Modifier.padding(topBarPadding))
                 }
             }
             composable(route = Screen.Statistic.name) {
                 Scaffold(
-                    topBar = { MensinatorTopBar(currentScreen) }
+                    topBar = { MensinatorTopBar(currentScreen) },
+                    contentWindowInsets = WindowInsets(0.dp),
                 ) { topBarPadding ->
                     StatisticsScreen(modifier = Modifier.padding(topBarPadding))
                 }
@@ -167,7 +169,8 @@ fun MensinatorApp(
                             }
                         }
                     },
-                    topBar = { MensinatorTopBar(currentScreen) }
+                    topBar = { MensinatorTopBar(currentScreen) },
+                    contentWindowInsets = WindowInsets(0.dp),
                 ) { topBarPadding ->
                     ManageSymptomScreen(
                         modifier = Modifier.padding(topBarPadding),
@@ -177,7 +180,8 @@ fun MensinatorApp(
             }
             composable(route = Screen.Settings.name) {
                 Scaffold(
-                    topBar = { MensinatorTopBar(currentScreen) }
+                    topBar = { MensinatorTopBar(currentScreen) },
+                    contentWindowInsets = WindowInsets(0.dp),
                 ) { topBarPadding ->
                     Column {
                         SettingsScreen(

--- a/app/src/main/java/com/mensinator/app/navigation/MensinatorApp.kt
+++ b/app/src/main/java/com/mensinator/app/navigation/MensinatorApp.kt
@@ -25,10 +25,12 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
-import com.mensinator.app.*
 import com.mensinator.app.R
+import com.mensinator.app.business.IPeriodDatabaseHelper
+import com.mensinator.app.calendar.CalendarScreen
 import com.mensinator.app.settings.SettingsScreen
 import com.mensinator.app.statistics.StatisticsScreen
+import com.mensinator.app.symptoms.ManageSymptomScreen
 import org.koin.compose.koinInject
 
 enum class Screen(@StringRes val titleRes: Int) {
@@ -187,6 +189,5 @@ fun MensinatorApp(
             }
         }
     }
-
 }
 

--- a/app/src/main/java/com/mensinator/app/navigation/MensinatorApp.kt
+++ b/app/src/main/java/com/mensinator/app/navigation/MensinatorApp.kt
@@ -31,6 +31,7 @@ import com.mensinator.app.calendar.CalendarScreen
 import com.mensinator.app.settings.SettingsScreen
 import com.mensinator.app.statistics.StatisticsScreen
 import com.mensinator.app.symptoms.ManageSymptomScreen
+import com.mensinator.app.ui.theme.UiConstants
 import org.koin.compose.koinInject
 
 enum class Screen(@StringRes val titleRes: Int) {
@@ -157,7 +158,7 @@ fun MensinatorApp(
                                 shape = CircleShape,
                                 modifier = Modifier
                                     .displayCutoutPadding()
-                                    .padding(5.dp)
+                                    .size(UiConstants.floatingActionButtonSize)
                             ) {
                                 Icon(
                                     imageVector = Icons.Default.Add,

--- a/app/src/main/java/com/mensinator/app/settings/ExportImportDialog.kt
+++ b/app/src/main/java/com/mensinator/app/settings/ExportImportDialog.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.settings
 
 import android.util.Log
 import android.widget.Toast
@@ -14,6 +14,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.mensinator.app.R
 import com.mensinator.app.ui.theme.MensinatorTheme
 import java.io.File
 import java.io.FileOutputStream

--- a/app/src/main/java/com/mensinator/app/settings/FaqDialog.kt
+++ b/app/src/main/java/com/mensinator/app/settings/FaqDialog.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.settings
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -17,6 +17,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.mensinator.app.R
 import com.mensinator.app.ui.theme.MensinatorTheme
 
 

--- a/app/src/main/java/com/mensinator/app/settings/NotificationDialog.kt
+++ b/app/src/main/java/com/mensinator/app/settings/NotificationDialog.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.settings
 
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -12,6 +12,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import com.mensinator.app.R
 import com.mensinator.app.ui.theme.MensinatorTheme
 
 @Composable

--- a/app/src/main/java/com/mensinator/app/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/mensinator/app/settings/SettingsScreen.kt
@@ -28,9 +28,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.mensinator.app.ExportDialog
-import com.mensinator.app.FaqDialog
-import com.mensinator.app.ImportDialog
 import com.mensinator.app.NotificationDialog
 import com.mensinator.app.R
 import com.mensinator.app.data.ColorSource

--- a/app/src/main/java/com/mensinator/app/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/mensinator/app/settings/SettingsScreen.kt
@@ -28,10 +28,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.mensinator.app.NotificationDialog
 import com.mensinator.app.R
 import com.mensinator.app.data.ColorSource
-import com.mensinator.app.navigation.displayCutoutExcludingStatusBarsPadding
+import com.mensinator.app.ui.navigation.displayCutoutExcludingStatusBarsPadding
 import com.mensinator.app.ui.theme.MensinatorTheme
 import com.mensinator.app.ui.theme.isDarkMode
 import org.koin.androidx.compose.koinViewModel

--- a/app/src/main/java/com/mensinator/app/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/mensinator/app/settings/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mensinator.app.NotificationDialog
 import com.mensinator.app.R
 import com.mensinator.app.data.ColorSource
+import com.mensinator.app.navigation.displayCutoutExcludingStatusBarsPadding
 import com.mensinator.app.ui.theme.MensinatorTheme
 import com.mensinator.app.ui.theme.isDarkMode
 import org.koin.androidx.compose.koinViewModel
@@ -112,6 +113,7 @@ fun SettingsScreen(
         modifier = modifier
             .padding(horizontal = 16.dp)
             .verticalScroll(rememberScrollState())
+            .displayCutoutExcludingStatusBarsPadding()
     ) {
         Spacer(Modifier.height(16.dp))
         SettingSectionHeader(text = stringResource(R.string.colors))

--- a/app/src/main/java/com/mensinator/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/mensinator/app/settings/SettingsViewModel.kt
@@ -7,8 +7,8 @@ import android.util.Log
 import android.widget.Toast
 import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
-import com.mensinator.app.IExportImport
-import com.mensinator.app.IPeriodDatabaseHelper
+import com.mensinator.app.business.IExportImport
+import com.mensinator.app.business.IPeriodDatabaseHelper
 import com.mensinator.app.R
 import com.mensinator.app.data.ColorSource
 import com.mensinator.app.settings.ColorSetting.*

--- a/app/src/main/java/com/mensinator/app/statistics/StatisticsScreen.kt
+++ b/app/src/main/java/com/mensinator/app/statistics/StatisticsScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mensinator.app.R
-import com.mensinator.app.navigation.displayCutoutExcludingStatusBarsPadding
+import com.mensinator.app.ui.navigation.displayCutoutExcludingStatusBarsPadding
 import com.mensinator.app.ui.theme.MensinatorTheme
 import org.koin.androidx.compose.koinViewModel
 

--- a/app/src/main/java/com/mensinator/app/statistics/StatisticsViewModel.kt
+++ b/app/src/main/java/com/mensinator/app/statistics/StatisticsViewModel.kt
@@ -4,6 +4,10 @@ import android.annotation.SuppressLint
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import com.mensinator.app.*
+import com.mensinator.app.business.ICalculationsHelper
+import com.mensinator.app.business.IOvulationPrediction
+import com.mensinator.app.business.IPeriodDatabaseHelper
+import com.mensinator.app.business.IPeriodPrediction
 import com.mensinator.app.extensions.formatToOneDecimalPoint
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
@@ -23,7 +23,7 @@ import com.mensinator.app.R
 import com.mensinator.app.data.ColorSource
 import com.mensinator.app.data.Symptom
 import com.mensinator.app.data.isActive
-import com.mensinator.app.navigation.displayCutoutExcludingStatusBarsPadding
+import com.mensinator.app.ui.navigation.displayCutoutExcludingStatusBarsPadding
 import com.mensinator.app.settings.ResourceMapper
 import com.mensinator.app.symptoms.ManageSymptomsViewModel.UiAction
 import com.mensinator.app.ui.theme.MensinatorTheme

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app
+package com.mensinator.app.symptoms
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -19,10 +19,17 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import com.mensinator.app.*
+import com.mensinator.app.R
+import com.mensinator.app.business.IPeriodDatabaseHelper
 import com.mensinator.app.data.ColorSource
+import com.mensinator.app.data.Symptom
+import com.mensinator.app.data.isActive
 import com.mensinator.app.settings.ResourceMapper
 import com.mensinator.app.navigation.displayCutoutExcludingStatusBarsPadding
+import com.mensinator.app.settings.SettingsViewModel
 import com.mensinator.app.ui.theme.isDarkMode
+import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
 
@@ -30,7 +37,8 @@ import org.koin.compose.koinInject
 @Composable
 fun ManageSymptomScreen(
     showCreateSymptom: MutableState<Boolean>,
-    modifier: Modifier,
+    modifier: Modifier = Modifier,
+    //viewModel: SettingsViewModel = koinViewModel(),
 ) {
     val dbHelper: IPeriodDatabaseHelper = koinInject()
     var initialSymptoms = remember { dbHelper.getAllSymptoms() }

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
@@ -1,11 +1,9 @@
 package com.mensinator.app.symptoms
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
@@ -22,18 +20,22 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.mensinator.app.R
 import com.mensinator.app.data.ColorSource
+import com.mensinator.app.data.isActive
 import com.mensinator.app.navigation.displayCutoutExcludingStatusBarsPadding
 import com.mensinator.app.settings.ResourceMapper
+import com.mensinator.app.ui.theme.MensinatorTheme
 import com.mensinator.app.ui.theme.UiConstants
 import com.mensinator.app.ui.theme.isDarkMode
 import org.koin.androidx.compose.koinViewModel
 
 // TODO: Improve Composable structure
-// TODO: Use tokens for shapes
 
 // TODO: Maybe delete savedSymptoms
 
-//Maps Database keys to res/strings.xml for multilanguage support
+private object SymptomScreenConstants {
+    val colorCircleSize = 24.dp
+}
+
 @Composable
 fun ManageSymptomScreen(
     modifier: Modifier = Modifier,
@@ -61,7 +63,6 @@ fun ManageSymptomScreen(
         savedSymptoms.forEach { symptom ->
             var expanded by remember { mutableStateOf(false) }
             var selectedColorName by remember { mutableStateOf(symptom.color) }
-            //val resKey = ResourceMapper.getStringResourceId(symptom.name)
             val selectedColor =
                 ColorSource.getColorMap(isDarkMode())[selectedColorName] ?: Color.Gray
 
@@ -71,7 +72,7 @@ fun ManageSymptomScreen(
                     viewModel.setSymptomToRename(symptom)
                 },
                 modifier = Modifier.fillMaxWidth(),
-                shape = RoundedCornerShape(25.dp),
+                shape = MaterialTheme.shapes.extraLarge,
             ) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
@@ -112,13 +113,6 @@ fun ManageSymptomScreen(
                     Box {
                         // Color Dropdown wrapped in a Box for alignment
                         Card(
-                            modifier = Modifier
-                                .padding(start = 10.dp)
-                                .clickable { }
-                                .clip(RoundedCornerShape(26.dp)),  // Make the entire row round
-                            colors = CardDefaults.cardColors(
-                                containerColor = Color.Transparent,
-                            ),
                             onClick = { expanded = true }
                         ) {
                             Row(
@@ -127,8 +121,8 @@ fun ManageSymptomScreen(
                             ) {
                                 Box(
                                     modifier = Modifier
-                                        .size(25.dp)
-                                        .clip(RoundedCornerShape(26.dp))
+                                        .size(SymptomScreenConstants.colorCircleSize)
+                                        .clip(CircleShape)
                                         .background(selectedColor),
                                 )
                                 Icon(
@@ -165,7 +159,7 @@ fun ManageSymptomScreen(
                                             if (colorValue != null) {
                                                 DropdownMenuItem(
                                                     modifier = Modifier
-                                                        .size(50.dp)
+                                                        .size(SymptomScreenConstants.colorCircleSize * 2)
                                                         .clip(CircleShape),
                                                     onClick = {
                                                         selectedColorName = colorName
@@ -187,8 +181,8 @@ fun ManageSymptomScreen(
                                                     text = {
                                                         Box(
                                                             modifier = Modifier
-                                                                .size(25.dp)
-                                                                .clip(RoundedCornerShape(26.dp))
+                                                                .size(SymptomScreenConstants.colorCircleSize)
+                                                                .clip(CircleShape)
                                                                 .background(colorValue)  // Use the color from the map
                                                         )
                                                     }
@@ -204,10 +198,9 @@ fun ManageSymptomScreen(
                     Spacer(modifier = Modifier.weight(0.05f))
 
                     Switch(
-                        checked = symptom.active == 1,
+                        checked = symptom.isActive,
                         onCheckedChange = { checked ->
-                            val updatedSymptom =
-                                symptom.copy(active = if (checked) 1 else 0)
+                            val updatedSymptom = symptom.copy(active = if (checked) 1 else 0)
                             savedSymptoms = savedSymptoms.map {
                                 if (it.id == symptom.id) updatedSymptom else it
                             }

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
@@ -16,10 +16,12 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.mensinator.app.R
 import com.mensinator.app.data.ColorSource
+import com.mensinator.app.data.Symptom
 import com.mensinator.app.data.isActive
 import com.mensinator.app.navigation.displayCutoutExcludingStatusBarsPadding
 import com.mensinator.app.settings.ResourceMapper
@@ -27,8 +29,6 @@ import com.mensinator.app.ui.theme.MensinatorTheme
 import com.mensinator.app.ui.theme.UiConstants
 import com.mensinator.app.ui.theme.isDarkMode
 import org.koin.androidx.compose.koinViewModel
-
-// TODO: Improve Composable structure
 
 // TODO: Maybe delete savedSymptoms
 
@@ -43,7 +43,7 @@ fun ManageSymptomScreen(
     setFabOnClick: (() -> Unit) -> Unit,
 ) {
     val state = viewModel.viewState.collectAsState()
-    var savedSymptoms = state.value.allSymptoms
+    val symptoms = state.value.allSymptoms
 
     LaunchedEffect(Unit) {
         setFabOnClick { viewModel.showCreateSymptomDialog(true) }
@@ -60,163 +60,12 @@ fun ManageSymptomScreen(
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        savedSymptoms.forEach { symptom ->
-            var expanded by remember { mutableStateOf(false) }
-            var selectedColorName by remember { mutableStateOf(symptom.color) }
-            val selectedColor =
-                ColorSource.getColorMap(isDarkMode())[selectedColorName] ?: Color.Gray
-
-            val symptomDisplayName = ResourceMapper.getStringResourceOrCustom(symptom.name)
-            Card(
-                onClick = {
-                    viewModel.setSymptomToRename(symptom)
-                },
-                modifier = Modifier.fillMaxWidth(),
-                shape = MaterialTheme.shapes.extraLarge,
-            ) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.Start,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 10.dp, end = 10.dp)
-                ) {
-                    if (savedSymptoms.size > 1) {
-                        IconButton(
-                            onClick = {
-                                val activeSymptoms = state.value.activeSymptoms
-                                if (activeSymptoms.contains(symptom)) {
-                                    viewModel.setSymptomToDelete(symptom)
-                                } else {
-                                    symptom.let { symptom ->
-                                        savedSymptoms = savedSymptoms.filter { it.id != symptom.id }
-                                        viewModel.deleteSymptom(symptom.id)
-                                    }
-                                }
-                            },
-                            modifier = Modifier.size(20.dp)
-                        ) {
-                            Icon(
-                                Icons.Default.Close,
-                                contentDescription = stringResource(id = R.string.close)
-                            )
-                        }
-                    }
-                    Spacer(modifier = Modifier.padding(start = 5.dp))
-                    Text(
-                        text = symptomDisplayName,
-                        textAlign = TextAlign.Left,
-                        modifier = Modifier.weight(1f) // Let the text expand to fill available space
-                    )
-
-                    //Color Picker Dropdown Menu
-                    Box {
-                        // Color Dropdown wrapped in a Box for alignment
-                        Card(
-                            onClick = { expanded = true }
-                        ) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.Center,
-                            ) {
-                                Box(
-                                    modifier = Modifier
-                                        .size(SymptomScreenConstants.colorCircleSize)
-                                        .clip(CircleShape)
-                                        .background(selectedColor),
-                                )
-                                Icon(
-                                    painter = painterResource(id = R.drawable.keyboard_arrow_down_24px),
-                                    contentDescription = stringResource(id = R.string.selection_color),
-                                    modifier = Modifier.wrapContentSize()
-                                )
-                            }
-                        }
-
-                        DropdownMenu(
-                            offset = DpOffset(x = (-50).dp, y = (10).dp),
-                            expanded = expanded,
-                            onDismissRequest = { expanded = false },
-                            modifier = Modifier
-                                .wrapContentSize()
-                        ) {
-                            // Retrieve the colorMap from DataSource
-                            val colorMap = ColorSource.getColorMap(isDarkMode())
-
-                            Column(
-                                modifier = Modifier.wrapContentSize(),
-                                verticalArrangement = Arrangement.Center,
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                ColorSource.colorsGroupedByHue.forEach { colorGroup ->
-                                    Row(
-                                        modifier = Modifier.wrapContentSize(),
-                                        horizontalArrangement = Arrangement.Center,
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        colorGroup.forEach { colorName ->
-                                            val colorValue = colorMap[colorName]
-                                            if (colorValue != null) {
-                                                DropdownMenuItem(
-                                                    modifier = Modifier
-                                                        .size(SymptomScreenConstants.colorCircleSize * 2)
-                                                        .clip(CircleShape),
-                                                    onClick = {
-                                                        selectedColorName = colorName
-                                                        expanded = false
-                                                        val updatedSymptom =
-                                                            symptom.copy(color = colorName)
-                                                        savedSymptoms = savedSymptoms.map {
-                                                            if (it.id == symptom.id) updatedSymptom else it
-                                                        }
-                                                        // Save settings to the database
-                                                        savedSymptoms.forEach { symptom ->
-                                                            viewModel.updateSymptom(
-                                                                symptom.id,
-                                                                symptom.active,
-                                                                symptom.color
-                                                            )
-                                                        }
-                                                    },
-                                                    text = {
-                                                        Box(
-                                                            modifier = Modifier
-                                                                .size(SymptomScreenConstants.colorCircleSize)
-                                                                .clip(CircleShape)
-                                                                .background(colorValue)  // Use the color from the map
-                                                        )
-                                                    }
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-
-                    Spacer(modifier = Modifier.weight(0.05f))
-
-                    Switch(
-                        checked = symptom.isActive,
-                        onCheckedChange = { checked ->
-                            val updatedSymptom = symptom.copy(active = if (checked) 1 else 0)
-                            savedSymptoms = savedSymptoms.map {
-                                if (it.id == symptom.id) updatedSymptom else it
-                            }
-                            // Save settings to the database
-                            savedSymptoms.forEach { symptom ->
-                                viewModel.updateSymptom(
-                                    symptom.id,
-                                    symptom.active,
-                                    symptom.color
-                                )
-                            }
-                        },
-                    )
-                    Spacer(modifier = Modifier.weight(0.05f))
-                }
-            }
+        symptoms.forEach { symptom ->
+            SymptomItem(
+                viewModel = viewModel,
+                symptom = symptom,
+                showDeletionIcon = symptoms.size > 1
+            )
         }
     }
 
@@ -235,8 +84,7 @@ fun ManageSymptomScreen(
     val symptomToRename = state.value.symptomToRename
     if (symptomToRename != null) {
         val symptomKey = ResourceMapper.getStringResourceId(symptomToRename.name)
-        val symptomDisplayName =
-            symptomKey?.let { stringResource(id = it) } ?: symptomToRename.name
+        val symptomDisplayName = symptomKey?.let { stringResource(id = it) } ?: symptomToRename.name
 
         RenameSymptomDialog(
             symptomDisplayName = symptomDisplayName,
@@ -260,6 +108,164 @@ fun ManageSymptomScreen(
             onCancel = {
                 viewModel.setSymptomToDelete(null)
             },
+        )
+    }
+}
+
+@Composable
+private fun SymptomItem(
+    viewModel: ManageSymptomsViewModel,
+    symptom: Symptom,
+    showDeletionIcon: Boolean
+) {
+    val selectedColor = ColorSource.getColorMap(isDarkMode())[symptom.color] ?: Color.Gray
+    val symptomDisplayName = ResourceMapper.getStringResourceOrCustom(symptom.name)
+
+    Card(
+        onClick = {
+            viewModel.setSymptomToRename(symptom)
+        },
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.extraLarge,
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 10.dp)
+        ) {
+            if (showDeletionIcon) {
+                IconButton(
+                    onClick = { viewModel.setSymptomToDelete(symptom) },
+                    modifier = Modifier.size(20.dp)
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = stringResource(id = R.string.close)
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.padding(start = 5.dp))
+            Text(
+                text = symptomDisplayName,
+                textAlign = TextAlign.Left,
+                modifier = Modifier.weight(1f) // Let the text expand to fill available space
+            )
+
+            //Color Picker Dropdown Menu
+            ColorPicker(selectedColor, symptom, viewModel)
+
+            Spacer(modifier = Modifier.weight(0.05f))
+
+            Switch(
+                checked = symptom.isActive,
+                onCheckedChange = { checked ->
+                    val updatedSymptom = symptom.copy(active = if (checked) 1 else 0)
+                    viewModel.updateSymptom(
+                        updatedSymptom.id,
+                        updatedSymptom.active,
+                        updatedSymptom.color
+                    )
+                },
+            )
+            Spacer(modifier = Modifier.weight(0.05f))
+        }
+    }
+}
+
+@Composable
+private fun ColorPicker(
+    selectedColor: Color,
+    symptom: Symptom,
+    viewModel: ManageSymptomsViewModel
+) {
+    var expanded by remember { mutableStateOf(false) }
+
+    Box {
+        // Color Dropdown wrapped in a Box for alignment
+        Card(
+            onClick = { expanded = true }
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(SymptomScreenConstants.colorCircleSize)
+                        .clip(CircleShape)
+                        .background(selectedColor),
+                )
+                Icon(
+                    painter = painterResource(id = R.drawable.keyboard_arrow_down_24px),
+                    contentDescription = stringResource(id = R.string.selection_color),
+                    modifier = Modifier.wrapContentSize()
+                )
+            }
+        }
+
+        DropdownMenu(
+            offset = DpOffset(x = (-50).dp, y = (10).dp),
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+            modifier = Modifier.wrapContentSize()
+        ) {
+            // Retrieve the colorMap from DataSource
+            val colorMap = ColorSource.getColorMap(isDarkMode())
+
+            Column(
+                modifier = Modifier.wrapContentSize(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                ColorSource.colorsGroupedByHue.forEach { colorGroup ->
+                    Row(
+                        modifier = Modifier.wrapContentSize(),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        colorGroup.forEach { colorName ->
+                            val colorValue = colorMap[colorName] ?: return@Row
+                            DropdownMenuItem(
+                                modifier = Modifier
+                                    .size(SymptomScreenConstants.colorCircleSize * 2)
+                                    .clip(CircleShape),
+                                onClick = {
+                                    expanded = false
+                                    val updatedSymptom = symptom.copy(color = colorName)
+                                    viewModel.updateSymptom(
+                                        updatedSymptom.id,
+                                        updatedSymptom.active,
+                                        updatedSymptom.color
+                                    )
+                                },
+                                text = {
+                                    Box(
+                                        modifier = Modifier
+                                            .size(SymptomScreenConstants.colorCircleSize)
+                                            .clip(CircleShape)
+                                            .background(colorValue)  // Use the color from the map
+                                    )
+                                }
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+// TODO: Broken
+@Preview(showBackground = true)
+@Composable
+private fun SymptomItemPreview() {
+    MensinatorTheme {
+        SymptomItem(
+            viewModel = koinViewModel(),
+            symptom = Symptom(1, "Medium flow", 1, "red"),
+            showDeletionIcon = true
         )
     }
 }

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
@@ -26,6 +27,14 @@ import com.mensinator.app.navigation.displayCutoutExcludingStatusBarsPadding
 import com.mensinator.app.ui.theme.isDarkMode
 import org.koin.androidx.compose.koinViewModel
 
+// TODO: Improve Composable structure
+// TODO: Use tokens for shapes
+// TODO: Maybe delete savedSymptoms
+// TODO: Define/use constant for 50.dp FAB size
+// TODO:
+// TODO:
+// TODO:
+// TODO:
 
 //Maps Database keys to res/strings.xml for multilanguage support
 @Composable
@@ -35,8 +44,7 @@ fun ManageSymptomScreen(
     setFabOnClick: (() -> Unit) -> Unit,
 ) {
     val state = viewModel.viewState.collectAsState()
-    var initialSymptoms = state.value.allSymptoms
-    var savedSymptoms = initialSymptoms
+    var savedSymptoms = state.value.allSymptoms
 
     LaunchedEffect(Unit) {
         setFabOnClick { viewModel.showCreateSymptomDialog(true) }
@@ -151,8 +159,7 @@ fun ManageSymptomScreen(
                             ) {
                                 ColorSource.colorsGroupedByHue.forEach { colorGroup ->
                                     Row(
-                                        modifier = Modifier
-                                            .wrapContentSize(),
+                                        modifier = Modifier.wrapContentSize(),
                                         horizontalArrangement = Arrangement.Center,
                                         verticalAlignment = Alignment.CenterVertically
                                     ) {
@@ -162,7 +169,7 @@ fun ManageSymptomScreen(
                                                 DropdownMenuItem(
                                                     modifier = Modifier
                                                         .size(50.dp)
-                                                        .clip(RoundedCornerShape(100.dp)),
+                                                        .clip(CircleShape),
                                                     onClick = {
                                                         selectedColorName = colorName
                                                         expanded = false
@@ -222,14 +229,13 @@ fun ManageSymptomScreen(
             }
         }
     }
+
     if (state.value.showCreateSymptomDialog) {
+        // TODO: remove newSymptom parameter?
         CreateNewSymptomDialog(
             newSymptom = "",  // Pass an empty string for new symptoms
             onSave = { newSymptomName ->
                 viewModel.createNewSymptom(newSymptomName)
-                // todo check whether this is needed
-                //initialSymptoms = state.value.allSymptoms // reset the data to make the new symptom appear
-                //savedSymptoms = initialSymptoms
                 viewModel.showCreateSymptomDialog(false)
             },
             onCancel = {
@@ -248,11 +254,6 @@ fun ManageSymptomScreen(
             symptomDisplayName = symptomDisplayName,
             onRename = { newName ->
                 viewModel.renameSymptom(symptomToRename.id, newName)
-
-                // todo check whether this is needed
-                //initialSymptoms = state.value.allSymptoms
-                //savedSymptoms = initialSymptoms
-
                 viewModel.setSymptomToRename(null)
             },
             onCancel = {
@@ -266,11 +267,6 @@ fun ManageSymptomScreen(
         DeleteSymptomDialog(
             onSave = {
                 viewModel.deleteSymptom(symptomToDelete.id)
-
-
-                // todo check whether this is needed
-                //savedSymptoms = savedSymptoms.filter { it.id != symptomToDelete.id }
-
                 viewModel.setSymptomToDelete(null)
             },
             onCancel = {

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
@@ -22,19 +22,16 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import com.mensinator.app.R
 import com.mensinator.app.data.ColorSource
-import com.mensinator.app.settings.ResourceMapper
 import com.mensinator.app.navigation.displayCutoutExcludingStatusBarsPadding
+import com.mensinator.app.settings.ResourceMapper
+import com.mensinator.app.ui.theme.UiConstants
 import com.mensinator.app.ui.theme.isDarkMode
 import org.koin.androidx.compose.koinViewModel
 
 // TODO: Improve Composable structure
 // TODO: Use tokens for shapes
+
 // TODO: Maybe delete savedSymptoms
-// TODO: Define/use constant for 50.dp FAB size
-// TODO:
-// TODO:
-// TODO:
-// TODO:
 
 //Maps Database keys to res/strings.xml for multilanguage support
 @Composable
@@ -57,7 +54,7 @@ fun ManageSymptomScreen(
             .verticalScroll(rememberScrollState())  // Make the column scrollable
             .displayCutoutExcludingStatusBarsPadding()
             .padding(16.dp)
-            .padding(bottom = 50.dp), // To be able to overscroll the list, to not have the FloatingActionButton overlapping
+            .padding(bottom = UiConstants.floatingActionButtonSize * 1.25f), // To be able to overscroll the list, to not have the FloatingActionButton overlapping
         verticalArrangement = Arrangement.spacedBy(16.dp),
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
@@ -231,9 +228,7 @@ fun ManageSymptomScreen(
     }
 
     if (state.value.showCreateSymptomDialog) {
-        // TODO: remove newSymptom parameter?
         CreateNewSymptomDialog(
-            newSymptom = "",  // Pass an empty string for new symptoms
             onSave = { newSymptomName ->
                 viewModel.createNewSymptom(newSymptomName)
                 viewModel.showCreateSymptomDialog(false)

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
@@ -23,9 +23,9 @@ import com.mensinator.app.R
 import com.mensinator.app.data.ColorSource
 import com.mensinator.app.data.Symptom
 import com.mensinator.app.data.isActive
-import com.mensinator.app.ui.navigation.displayCutoutExcludingStatusBarsPadding
 import com.mensinator.app.settings.ResourceMapper
 import com.mensinator.app.symptoms.ManageSymptomsViewModel.UiAction
+import com.mensinator.app.ui.navigation.displayCutoutExcludingStatusBarsPadding
 import com.mensinator.app.ui.theme.MensinatorTheme
 import com.mensinator.app.ui.theme.UiConstants
 import com.mensinator.app.ui.theme.isDarkMode
@@ -94,7 +94,6 @@ fun ManageSymptomScreen(
             },
             onCancel = {
                 viewModel.onAction(UiAction.HideRenamingDialog)
-
             }
         )
     }

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsDialogs.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsDialogs.kt
@@ -27,6 +27,7 @@ fun CreateNewSymptomDialog(
                 onClick = {
                     onSave(symptomName)
                 },
+                enabled = symptomName.isNotBlank()
             ) {
                 Text(stringResource(id = R.string.save_button))
             }

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsDialogs.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsDialogs.kt
@@ -1,104 +1,16 @@
-package com.mensinator.app
+package com.mensinator.app.symptoms
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material3.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.*
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import com.mensinator.app.settings.ResourceMapper
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
+import com.mensinator.app.R
 import com.mensinator.app.ui.theme.MensinatorTheme
-import java.time.LocalDate
-
-
-@Composable
-fun SymptomsDialog(
-    date: LocalDate,
-    symptoms: List<Symptom>,
-    dbHelper: IPeriodDatabaseHelper,
-    onSave: (List<Symptom>) -> Unit,
-    onCancel: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    var selectedSymptoms by remember { mutableStateOf(emptySet<Symptom>()) }
-
-    LaunchedEffect(date) {
-        val symptomIdsForDate = dbHelper.getSymptomsFromDate(date).toSet()
-        selectedSymptoms = symptoms.filter { it.id in symptomIdsForDate }.toSet()
-    }
-
-    AlertDialog(
-        onDismissRequest = { onCancel() },
-        confirmButton = {
-            Button(
-                onClick = {
-                    onSave(selectedSymptoms.toList())
-                },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(text = stringResource(id = R.string.save_symptoms_button))
-            }
-        },
-        modifier = modifier,
-        dismissButton = {
-            Button(
-                onClick = {
-                    onCancel()
-                },
-                modifier = Modifier.fillMaxWidth()
-            ) {
-                Text(text = stringResource(id = R.string.cancel_button))
-            }
-        },
-        title = {
-            Text(text = stringResource(id = R.string.symptoms_dialog_title, date))
-        },
-        text = {
-            Column(modifier = Modifier.verticalScroll(rememberScrollState())) {
-                symptoms.forEach { symptom ->
-                    val symptomKey = ResourceMapper.getStringResourceId(symptom.name)
-                    val symptomDisplayName = symptomKey?.let { stringResource(id = it) } ?: symptom.name
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(8.dp)
-                            .clickable {
-                                selectedSymptoms = if (selectedSymptoms.contains(symptom)) {
-                                    selectedSymptoms - symptom
-                                } else {
-                                    selectedSymptoms + symptom
-                                }
-                            },
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Checkbox(
-                            checked = selectedSymptoms.contains(symptom),
-                            onCheckedChange = null
-                        )
-                        Spacer(modifier = Modifier.width(8.dp))
-                        Text(text = symptomDisplayName, fontSize = 16.sp)
-                    }
-                }
-//                Spacer(modifier = Modifier.height(16.dp))
-//                Button(
-//                    onClick = {
-//                        onCreateNewSymptom()
-//                    },
-//                    modifier = Modifier.fillMaxWidth()
-//                ) {
-//                    Text(text = stringResource(id = R.string.create_new_symptom_button))
-//                }
-            }
-        },
-    )
-}
-
 
 @Composable
 fun CreateNewSymptomDialog(
@@ -108,7 +20,6 @@ fun CreateNewSymptomDialog(
     modifier: Modifier = Modifier,
 ) {
     var symptomName by remember { mutableStateOf(newSymptom) }
-    //val symptomKey = ResourceMapper.getStringResourceId(symptomName)
 
     AlertDialog(
         onDismissRequest = onCancel,

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsDialogs.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsDialogs.kt
@@ -14,12 +14,11 @@ import com.mensinator.app.ui.theme.MensinatorTheme
 
 @Composable
 fun CreateNewSymptomDialog(
-    newSymptom: String,
     onSave: (String) -> Unit,
     onCancel: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    var symptomName by remember { mutableStateOf(newSymptom) }
+    var symptomName by remember { mutableStateOf("") }
 
     AlertDialog(
         onDismissRequest = onCancel,
@@ -136,7 +135,6 @@ fun DeleteSymptomDialog(
 private fun CreateNewSymptomDialogPreview() {
     MensinatorTheme {
         CreateNewSymptomDialog(
-            newSymptom = "preview",
             onSave = {},
             onCancel = {}
         )

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsViewModel.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsViewModel.kt
@@ -1,7 +1,5 @@
 package com.mensinator.app.symptoms
 
-import android.annotation.SuppressLint
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mensinator.app.business.IPeriodDatabaseHelper
@@ -15,7 +13,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class ManageSymptomsViewModel(
-    @SuppressLint("StaticFieldLeak") private val appContext: Context,
     private val periodDatabaseHelper: IPeriodDatabaseHelper,
 ) : ViewModel() {
 

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsViewModel.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsViewModel.kt
@@ -1,0 +1,41 @@
+package com.mensinator.app.symptoms
+
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import com.mensinator.app.*
+import com.mensinator.app.business.ICalculationsHelper
+import com.mensinator.app.business.IOvulationPrediction
+import com.mensinator.app.business.IPeriodDatabaseHelper
+import com.mensinator.app.business.IPeriodPrediction
+import com.mensinator.app.extensions.formatToOneDecimalPoint
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+
+class ManageSymptomsViewModel(
+    @SuppressLint("StaticFieldLeak") private val appContext: Context,
+    private val periodDatabaseHelper: IPeriodDatabaseHelper,
+) : ViewModel() {
+
+
+    private val _viewState = MutableStateFlow(
+        ViewState()
+    )
+    val viewState: StateFlow<ViewState> = _viewState.asStateFlow()
+
+    data class ViewState(
+        val trackedPeriods: String? = null,
+    )
+
+    fun refreshData() {
+        _viewState.update {
+            it.copy(
+                trackedPeriods = periodDatabaseHelper.getPeriodCount().toString(),
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsViewModel.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomsViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mensinator.app.business.IPeriodDatabaseHelper
 import com.mensinator.app.data.Symptom
-import com.mensinator.app.data.isActive
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -27,7 +26,6 @@ class ManageSymptomsViewModel(
 
     data class ViewState(
         val allSymptoms: List<Symptom> = listOf(),
-        val activeSymptoms: List<Symptom> = listOf(),
         val showCreateSymptomDialog: Boolean = false,
         val symptomToRename: Symptom? = null,
         val symptomToDelete: Symptom? = null,
@@ -51,11 +49,9 @@ class ManageSymptomsViewModel(
 
     suspend fun refreshData() {
         withContext(Dispatchers.IO) {
-            val allSymptoms = periodDatabaseHelper.getAllSymptoms()
             _viewState.update {
                 it.copy(
                     allSymptoms = periodDatabaseHelper.getAllSymptoms(),
-                    activeSymptoms = allSymptoms.filter { it.isActive },
                 )
             }
         }

--- a/app/src/main/java/com/mensinator/app/ui/navigation/BarItem.kt
+++ b/app/src/main/java/com/mensinator/app/ui/navigation/BarItem.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app.navigation
+package com.mensinator.app.ui.navigation
 
 data class BarItem(
     val screen: Screen,

--- a/app/src/main/java/com/mensinator/app/ui/navigation/MensinatorApp.kt
+++ b/app/src/main/java/com/mensinator/app/ui/navigation/MensinatorApp.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app.navigation
+package com.mensinator.app.ui.navigation
 
 import android.util.Log
 import androidx.annotation.StringRes

--- a/app/src/main/java/com/mensinator/app/ui/navigation/MensinatorTopBar.kt
+++ b/app/src/main/java/com/mensinator/app/ui/navigation/MensinatorTopBar.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app.navigation
+package com.mensinator.app.ui.navigation
 
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.MaterialTheme

--- a/app/src/main/java/com/mensinator/app/ui/theme/UiConstants.kt
+++ b/app/src/main/java/com/mensinator/app/ui/theme/UiConstants.kt
@@ -1,0 +1,7 @@
+package com.mensinator.app.ui.theme
+
+import androidx.compose.ui.unit.dp
+
+object UiConstants {
+    val floatingActionButtonSize = 56.dp
+}

--- a/app/src/test/java/com/mensinator/app/PeriodPredictionTest.kt
+++ b/app/src/test/java/com/mensinator/app/PeriodPredictionTest.kt
@@ -1,5 +1,9 @@
 package com.mensinator.app
 
+import com.mensinator.app.business.ICalculationsHelper
+import com.mensinator.app.business.IPeriodDatabaseHelper
+import com.mensinator.app.business.IPeriodPrediction
+import com.mensinator.app.business.PeriodPrediction
 import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,40 +1,24 @@
-<h1> Mensinator </h1>
-Mensinator is the ultimate period tracker designed for those who prioritize simplicity, privacy, and user-friendliness. 🌟
-
-<h2> Overview </h2>
-Mensinator provides a clean and intuitive interface for tracking your menstrual cycle, monitoring your periods, and viewing essential statistics—all without the need for sign-ups or sharing personal data. All information is stored securely on your device, ensuring your privacy is always protected. 🛡️
-
-<h2> Key Features </h2>
-- Effortless Period Tracking: Easily mark your periods, view your cycle, and access statistics all in one place. 📅
-- No Sign-Up Required: Start using the app immediately—no account creation or personal information required. 🎉
-- Complete Privacy: Your data is stored locally on your device. We do not collect, share, or sell any personal information. 🔒
-- Easy Navigation: Quickly switch between months and track your cycle with just a few taps. 🖐️
-- Clear Statistics: Instantly view your average cycle length, average period length, and next period prediction right below your calendar. 📊
-- Historical Insights: Get a summary of all your tracked periods to better understand your menstrual health over time. 📈
-- Visual Indicators: See visual indicators on the calendar for existing periods and selected dates. 🔴🔵
-- Customizable Colors: Personalize the app's appearance by customizing colors to your preference. 🎨
-- Export and Import Data: Easily export your data to a JSON file for backup or transfer and import it back into the app whenever needed. 📂
-- Why Choose Mensinator?
-- Mensinator stands out for its simplicity and dedication to privacy. With just one main view, you can track your periods, view statistics, and manage your menstrual health without any complications. The app does not require sign-ups or collect personal data, providing an effective and private way to keep track of your cycle.
-
-<h2> How It Works </h2>
-- Track Your Periods: Select dates on the calendar to mark your periods and monitor your cycle.
-- View Statistics: Check your average cycle length, average period length, and next period prediction effortlessly.
-- Save and Refresh: Click the "Save" button to update your data and refresh your statistics.
-- Export and Import Data: Use the export feature to save your data as a JSON file and the import feature to load data back into the app.
-
-<h2> Who Should Use It? </h2>
-Mensinator is perfect for anyone seeking a straightforward and private period tracking solution. Whether you're tracking for health reasons or simply keeping an eye on your cycle, Mensinator makes it easy and secure.
-
-<h2> Getting Started</h2>
-To get started with Mensinator, you can either get it from IzzyOnDroid or from GooglePlay and start tracking your menstrual cycle with ease and privacy.
-<strong><a href="https://play.google.com/store/apps/details?id=com.mensinator.app">https://play.google.com/store/apps/details?id=com.mensinator.app</a></strong>
-<strong><a href="https://apt.izzysoft.de/fdroid/index/apk/com.mensinator.app</a></strong>
-
-
-<h2> Contributing </h2>
-We welcome contributions to improve Mensinator! If you'd like to contribute, please fork the repository and submit a pull request. For major changes, please open an issue first to discuss your proposed changes. You are also welcome to join our Discord to discuss further or simply to chat with us!
-Join us here; <strong><a href="https://discord.gg/tHA2k3bFRN</a></strong>
-
-<h2> License </h2>
-This project is licensed under the MIT License - see the LICENSE file for details.
+<h4>Mensinator</h4>
+<p>Mensinator is the ultimate period tracker designed for those who prioritize simplicity, privacy, and user-friendliness. 🌟</p>
+<h4>Overview</h4>
+<p>Mensinator provides a clean and intuitive interface for tracking your menstrual cycle, monitoring your periods, and viewing essential statistics—all without the need for sign-ups or sharing personal data. All information is stored securely on your device, ensuring your privacy is always protected. 🛡️</p>
+<h4>Key Features</h4>
+<ul>
+<li>Effortless Period Tracking: Easily mark your periods, view your cycle, and access statistics all in one place. 📅</li>
+<li>No Sign-Up Required: Start using the app immediately—no account creation or personal information required. 🎉</li>
+<li>Complete Privacy: Your data is stored locally on your device. We do not collect, share, or sell any personal information. 🔒</li>
+<li>Easy Navigation: Quickly switch between months and track your cycle with just a few taps. 🖐️</li>
+<li>Clear Statistics: Instantly view your average cycle length, average period length, and next period prediction right below your calendar. 📊</li>
+<li>Historical Insights: Get a summary of all your tracked periods to better understand your menstrual health over time. 📈</li>
+<li>Visual Indicators: See visual indicators on the calendar for existing periods and selected dates. 🔴🔵</li>
+<li>Customizable Colors: Personalize the app's appearance by customizing colors to your preference. 🎨</li>
+<li>Export and Import Data: Easily export your data to a JSON file for backup or transfer and import it back into the app whenever needed. 📂</li>
+</ul>
+<h4>Who Should Use It?</h4>
+<p>Mensinator is perfect for anyone seeking a straightforward and private period tracking solution. Whether you're tracking for health reasons or simply keeping an eye on your cycle, Mensinator makes it easy and secure.</p>
+<h4>Getting Started</h4>
+<p>To get started with Mensinator, you can either get it from <a href="https://apt.izzysoft.de/packages/com.mensinator.app">IzzyOnDroid</a> or from <a href="https://play.google.com/store/apps/details?id=com.mensinator.app">GooglePlay</a> and start tracking your menstrual cycle with ease and privacy.</p>
+<p></p>
+<h4>Contributing</h4>We welcome contributions to improve Mensinator! If you'd like to contribute, please fork the repository and submit a pull request. For major changes, please open an issue first to discuss your proposed changes. You are also welcome to join <a href="https://discord.gg/tHA2k3bFRN">our Discord</a> to discuss further or simply to chat with us!</p>
+<h4>License</h4>
+<p>This project is licensed under the MIT License - see the LICENSE file for details.</p>


### PR DESCRIPTION
This refactoring includes many bugfixes relating to the Manage Symptoms screen:
* When symptoms were getting create + colors were changed, the color values were not saved to the correct symptoms. It was just overall buggy.
* Symptom creation now requires the user to type in a symptom name. A blank name is not valid anymore


Important changes:
* Package structure of the app was changed
* `PeriodDataBaseHelper` no longer calls `db.close`. At `ManageSymptomsViewModel` I introduced `withContext(Dispatchers.IO) {`, which performs the DB calls in the background. Multiple DB calls at the same time are fine. But not, when one has completed and calls `db.close()` while the other is still interacting with the DB.


Minor fix: Display cutout insets at Settings screen, insets fixes at MensinatorApp