### PR TITLE
Remove <b> tags from the "about app" dialogue

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,7 +148,7 @@
     <string name="features_coming_soon">Features Coming Soon:</string>
     <string name="upcoming_features">• Check our Github for the latest regarding the apps development!</string>
     <string name="our_story_header">Our Story</string>
-    <string name="our_story">We are two women who were tired of selling our data to big corporations. Our app stores all your data locally on your device and we have &lt;b&gt;no access to it whatsoever&lt;/b&gt;.\nWe value your privacy and do not save or share any personal information. Since launching this app we have grown and now have our own Discord server with people who are passionate about this app and want to help us out!\n\nJoin us on Discord here: https://discord.gg/tHA2k3bFRN</string>
+    <string name="our_story">We are two women who were tired of selling our data to big corporations. Our app stores all your data locally on your device and we have no access to it whatsoever.\nWe value your privacy and do not save or share any personal information. Since launching this app we have grown and now have our own Discord server with people who are passionate about this app and want to help us out!\n\nJoin us on Discord here: https://discord.gg/tHA2k3bFRN</string>
     <string name="disclaimer_header">Disclaimer:</string>
     <string name="disclaimer">• This is a hobby project and is not intended for medical use. We are simply doing this for our own needs. But we do welcome ideas and requests. Join us on Discord or send us an email:\nmensinator.app@gmail.com</string>
 


### PR DESCRIPTION
Tags were not being rendered correctly in the app
![about](https://github.com/user-attachments/assets/d6417ac9-9f94-4903-af62-d5929cd7bc0f)
