### PR TITLE
Schedule notifications both at Calendar and Settings screens; improve settings handling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,10 @@ android {
         reportsDestination = layout.buildDirectory.dir("compose_compiler")
         metricsDestination = layout.buildDirectory.dir("compose_compiler")
     }
+    @Suppress("UnstableApiUsage")
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
 }
 
 dependencies {
@@ -93,10 +97,12 @@ dependencies {
     implementation(libs.koin)
     implementation(libs.koin.compose)
 
+    implementation(libs.kotlinx.coroutines)
     implementation(libs.kotlinx.collections.immutable)
 
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
+    testImplementation(libs.kotlinx.coroutines.test)
 
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/mensinator/app/App.kt
+++ b/app/src/main/java/com/mensinator/app/App.kt
@@ -3,6 +3,10 @@ package com.mensinator.app
 import android.app.AlarmManager
 import android.app.Application
 import com.mensinator.app.business.*
+import com.mensinator.app.business.notifications.AndroidNotificationScheduler
+import com.mensinator.app.business.notifications.IAndroidNotificationScheduler
+import com.mensinator.app.business.notifications.INotificationScheduler
+import com.mensinator.app.business.notifications.NotificationScheduler
 import com.mensinator.app.calendar.CalendarViewModel
 import com.mensinator.app.settings.SettingsViewModel
 import com.mensinator.app.statistics.StatisticsViewModel

--- a/app/src/main/java/com/mensinator/app/App.kt
+++ b/app/src/main/java/com/mensinator/app/App.kt
@@ -28,6 +28,7 @@ class App : Application() {
         singleOf(::ExportImport) { bind<IExportImport>() }
         singleOf(::NotificationScheduler) { bind<INotificationScheduler>() }
         singleOf(::DefaultDispatcherProvider) { bind<IDispatcherProvider>() }
+        singleOf(::AndroidNotificationScheduler) { bind<IAndroidNotificationScheduler>() }
         single { androidContext().getSystemService(ALARM_SERVICE) as AlarmManager }
 
         viewModel { CalendarViewModel(get(), get(), get(), get()) }

--- a/app/src/main/java/com/mensinator/app/App.kt
+++ b/app/src/main/java/com/mensinator/app/App.kt
@@ -1,11 +1,14 @@
 package com.mensinator.app
 
+import android.app.AlarmManager
 import android.app.Application
 import com.mensinator.app.business.*
 import com.mensinator.app.calendar.CalendarViewModel
 import com.mensinator.app.settings.SettingsViewModel
 import com.mensinator.app.statistics.StatisticsViewModel
 import com.mensinator.app.symptoms.ManageSymptomsViewModel
+import com.mensinator.app.utils.DefaultDispatcherProvider
+import com.mensinator.app.utils.IDispatcherProvider
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
@@ -24,10 +27,12 @@ class App : Application() {
         singleOf(::PeriodPrediction) { bind<IPeriodPrediction>() }
         singleOf(::ExportImport) { bind<IExportImport>() }
         singleOf(::NotificationScheduler) { bind<INotificationScheduler>() }
+        singleOf(::DefaultDispatcherProvider) { bind<IDispatcherProvider>() }
+        single { androidContext().getSystemService(ALARM_SERVICE) as AlarmManager }
 
         viewModel { CalendarViewModel(get(), get(), get(), get()) }
         viewModel { ManageSymptomsViewModel(get()) }
-        viewModel { SettingsViewModel(get(), get(), get()) }
+        viewModel { SettingsViewModel(get(), get(), get(), get()) }
         viewModel { StatisticsViewModel(get(), get(), get(), get(), get()) }
     }
 

--- a/app/src/main/java/com/mensinator/app/MainActivity.kt
+++ b/app/src/main/java/com/mensinator/app/MainActivity.kt
@@ -9,9 +9,19 @@ import android.view.WindowManager
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import com.mensinator.app.NotificationChannelConstants.channelDescription
+import com.mensinator.app.NotificationChannelConstants.channelId
+import com.mensinator.app.NotificationChannelConstants.channelName
 import com.mensinator.app.ui.navigation.MensinatorApp
 import com.mensinator.app.ui.theme.MensinatorTheme
 import org.koin.androidx.compose.KoinAndroidContext
+
+@Suppress("ConstPropertyName")
+object NotificationChannelConstants {
+    const val channelId = "1"
+    const val channelName = "Mensinator"
+    const val channelDescription = "Your Channel Description"
+}
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -29,9 +39,6 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun createNotificationChannel(context: Context) {
-        val channelId = "1"
-        val channelName = "Mensinator"
-        val channelDescription = "Your Channel Description"
         val importance = NotificationManager.IMPORTANCE_HIGH
         val notificationChannel = NotificationChannel(channelId, channelName, importance).apply {
             description = channelDescription

--- a/app/src/main/java/com/mensinator/app/MainActivity.kt
+++ b/app/src/main/java/com/mensinator/app/MainActivity.kt
@@ -20,7 +20,7 @@ import org.koin.androidx.compose.KoinAndroidContext
 object NotificationChannelConstants {
     const val channelId = "1"
     const val channelName = "Mensinator"
-    const val channelDescription = "Your Channel Description"
+    const val channelDescription = "Reminders about upcoming periods"
 }
 
 class MainActivity : AppCompatActivity() {

--- a/app/src/main/java/com/mensinator/app/NotificationReceiver.kt
+++ b/app/src/main/java/com/mensinator/app/NotificationReceiver.kt
@@ -1,5 +1,6 @@
 package com.mensinator.app
 
+import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -17,11 +18,23 @@ class NotificationReceiver : BroadcastReceiver() {
 
     override fun onReceive(context: Context, intent: Intent) {
         val messageText = intent.getStringExtra(MESSAGE_TEXT_KEY)
-        // Create and show the notification
+
+        val launchIntent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+        }
+
+        val pendingIntent = PendingIntent.getActivity(
+            context,
+            0,
+            launchIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE // FLAG_IMMUTABLE required for Android 12+
+        )
+
         val notificationBuilder = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.baseline_bloodtype_24)
             .setContentTitle("Mensinator")
             .setContentText(messageText)
+            .setContentIntent(pendingIntent)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
 
         val notificationManager = NotificationManagerCompat.from(context)

--- a/app/src/main/java/com/mensinator/app/NotificationReceiver.kt
+++ b/app/src/main/java/com/mensinator/app/NotificationReceiver.kt
@@ -32,8 +32,7 @@ class NotificationReceiver : BroadcastReceiver() {
 
         val notificationBuilder = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.baseline_bloodtype_24)
-            .setContentTitle("Mensinator")
-            .setContentText(messageText)
+            .setContentText(messageText) // See discussion at https://github.com/EmmaTellblom/Mensinator/issues/216
             .setContentIntent(pendingIntent)
             .setPriority(NotificationCompat.PRIORITY_HIGH)
 

--- a/app/src/main/java/com/mensinator/app/business/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/AndroidNotificationScheduler.kt
@@ -1,0 +1,47 @@
+package com.mensinator.app.business
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import com.mensinator.app.NotificationReceiver
+import java.time.LocalDate
+import java.time.ZoneId
+
+class AndroidNotificationScheduler(
+    private val context: Context,
+    private val alarmManager: AlarmManager,
+) : IAndroidNotificationScheduler {
+    override fun scheduleNotification(
+        messageText: String,
+        notificationDate: LocalDate
+    ) {
+        val notificationTimeMillis =
+            notificationDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+        alarmManager.set(
+            AlarmManager.RTC_WAKEUP,
+            notificationTimeMillis,
+            getPendingIntent(messageText)
+        )
+        Log.d("NotificationScheduler", "Notification scheduled for $notificationDate")
+    }
+
+    override fun cancelScheduledNotification() {
+        alarmManager.cancel(getPendingIntent(messageText = null))
+        Log.d("NotificationScheduler", "Notification cancelled")
+    }
+
+    private fun getPendingIntent(messageText: String?): PendingIntent {
+        val intent = Intent(context, NotificationReceiver::class.java).apply {
+            action = NotificationReceiver.ACTION_NOTIFICATION
+            messageText?.let { putExtra(NotificationReceiver.MESSAGE_TEXT_KEY, it) }
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            0,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+}

--- a/app/src/main/java/com/mensinator/app/business/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/AndroidNotificationScheduler.kt
@@ -9,6 +9,9 @@ import com.mensinator.app.NotificationReceiver
 import java.time.LocalDate
 import java.time.ZoneId
 
+/**
+ * Allows scheduling/cancelling notifications on Android.
+ */
 class AndroidNotificationScheduler(
     private val context: Context,
     private val alarmManager: AlarmManager,

--- a/app/src/main/java/com/mensinator/app/business/IAndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/IAndroidNotificationScheduler.kt
@@ -1,0 +1,12 @@
+package com.mensinator.app.business
+
+import java.time.LocalDate
+
+interface IAndroidNotificationScheduler {
+    fun scheduleNotification(
+        messageText: String,
+        notificationDate: LocalDate
+    )
+
+    fun cancelScheduledNotification()
+}

--- a/app/src/main/java/com/mensinator/app/business/INotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/INotificationScheduler.kt
@@ -1,8 +1,8 @@
 package com.mensinator.app.business
 
-import java.time.LocalDate
-
 interface INotificationScheduler {
-    fun scheduleNotification(notificationDate: LocalDate, messageText: String)
-    fun cancelNotification(notificationId: Int)
+    /**
+     * Checks if there is enough data to schedule a period reminder notification, then schedules it.
+     */
+    suspend fun schedulePeriodNotification()
 }

--- a/app/src/main/java/com/mensinator/app/business/IPeriodDatabaseHelper.kt
+++ b/app/src/main/java/com/mensinator/app/business/IPeriodDatabaseHelper.kt
@@ -55,7 +55,7 @@ interface IPeriodDatabaseHelper {
     fun getAllSettings(): List<Setting>
 
     // This function is used for updating settings in the database
-    fun updateSetting(key: String, value: String): Boolean
+    suspend fun updateSetting(key: String, value: String): Boolean
 
     // This function is used to get a setting from the database
     suspend fun getSettingByKey(key: String): Setting?

--- a/app/src/main/java/com/mensinator/app/business/NotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/NotificationScheduler.kt
@@ -6,44 +6,84 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.util.Log
-import androidx.core.app.NotificationManagerCompat
 import com.mensinator.app.NotificationReceiver
+import com.mensinator.app.settings.IntSetting
+import com.mensinator.app.settings.StringSetting
+import com.mensinator.app.ui.ResourceMapper
+import com.mensinator.app.utils.IDispatcherProvider
+import kotlinx.coroutines.withContext
 import java.time.LocalDate
 import java.time.ZoneId
 
 class NotificationScheduler(
-    private val context: Context
+    private val context: Context,
+    private val dbHelper: IPeriodDatabaseHelper,
+    private val periodPrediction: IPeriodPrediction,
+    private val dispatcherProvider: IDispatcherProvider,
+    private val alarmManager: AlarmManager
 ) : INotificationScheduler {
 
-    override fun scheduleNotification(notificationDate: LocalDate, messageText: String) {
-        val notificationManager = NotificationManagerCompat.from(context)
-        notificationManager.cancelAll()
-        Log.d("NotificationScheduler", "Notification canceled")
-        val notificationTimeInMillis = notificationDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+    // Schedule notification for reminder
+    // Check that reminders should be scheduled (reminder>0)
+    // and that it's more then reminderDays left (do not schedule notifications where there's too few reminderDays left until period)
+    override suspend fun schedulePeriodNotification() {
+        withContext(dispatcherProvider.IO) {
+            val periodReminderDays =
+                dbHelper.getSettingByKey(IntSetting.REMINDER_DAYS.settingDbKey)?.value?.toIntOrNull() ?: 2
+            val nextPeriodDate = periodPrediction.getPredictedPeriodDate()
+            val initPeriodKeyOrCustomMessage =
+                dbHelper.getStringSettingByKey(StringSetting.PERIOD_NOTIFICATION_MESSAGE.settingDbKey)
+            val periodMessageText =
+                ResourceMapper.getPeriodReminderMessage(initPeriodKeyOrCustomMessage, context)
 
-        val intent = Intent(context, NotificationReceiver::class.java).apply {
-            action = NotificationReceiver.ACTION_NOTIFICATION
-            putExtra(NotificationReceiver.MESSAGE_TEXT_KEY, messageText)
+            val notificationDate = getNotificationScheduleDate(periodReminderDays, nextPeriodDate)
+
+
+            withContext(dispatcherProvider.Main) {
+                val intent = Intent(context, NotificationReceiver::class.java).apply {
+                    action = NotificationReceiver.ACTION_NOTIFICATION
+                    putExtra(NotificationReceiver.MESSAGE_TEXT_KEY, periodMessageText)
+                }
+                val pendingIntent = PendingIntent.getBroadcast(
+                    context,
+                    0,
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+
+                if (notificationDate != null) {
+                    val notificationTimeMillis = notificationDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli()
+                    alarmManager.set(
+                        AlarmManager.RTC_WAKEUP,
+                        notificationTimeMillis,
+                        pendingIntent
+                    )
+                    Log.d("NotificationScheduler", "Notification scheduled for $notificationDate")
+                } else {
+                    // Make sure the scheduled notification is cancelled, if the user data/conditions become invalid.
+                    alarmManager.cancel(pendingIntent)
+                    Log.d("NotificationScheduler", "Notification cancelled")
+                }
+            }
         }
-        val pendingIntent = PendingIntent.getBroadcast(
-            context,
-            0,
-            intent,
-            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-        )
-
-        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
-        alarmManager.set(
-            AlarmManager.RTC_WAKEUP,
-            notificationTimeInMillis,
-            pendingIntent
-        )
-
-        Log.d("NotificationScheduler", "Notification scheduled for $notificationDate")
     }
 
-    override fun cancelNotification(notificationId: Int) {
-        val notificationManager = NotificationManagerCompat.from(context)
-        notificationManager.cancel(notificationId)
+    // If the date checks pass, return the notification schedule date.
+    private fun getNotificationScheduleDate(
+        periodReminderDays: Int,
+        nextPeriodDate: LocalDate?
+    ): LocalDate? {
+        if (periodReminderDays <= 0 || nextPeriodDate == null) return null
+
+        val notificationDate = nextPeriodDate.minusDays(periodReminderDays.toLong())
+        if (notificationDate.isBefore(LocalDate.now())) {
+            Log.d(
+                "CalendarScreen",
+                "Notification not scheduled because the reminder date is in the past"
+            )
+            return null
+        }
+
+        return nextPeriodDate.minusDays(periodReminderDays.toLong())
     }
 }

--- a/app/src/main/java/com/mensinator/app/business/NotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/NotificationScheduler.kt
@@ -1,20 +1,20 @@
 package com.mensinator.app.business
 
 
-import android.app.AlarmManager
-import android.app.PendingIntent
 import android.content.Context
-import android.content.Intent
 import android.util.Log
-import com.mensinator.app.NotificationReceiver
 import com.mensinator.app.settings.IntSetting
 import com.mensinator.app.settings.StringSetting
 import com.mensinator.app.ui.ResourceMapper
 import com.mensinator.app.utils.IDispatcherProvider
 import kotlinx.coroutines.withContext
 import java.time.LocalDate
-import java.time.ZoneId
 
+/**
+ * Service that checks whether a notification should be scheduled or cancelled.
+ * Does not perform the actual scheduling itself, instead it delegates this to [IAndroidNotificationScheduler].
+ * This is done to be able to unit test this class without using Robolectric.
+ */
 class NotificationScheduler(
     private val context: Context,
     private val dbHelper: IPeriodDatabaseHelper,

--- a/app/src/main/java/com/mensinator/app/business/notifications/AndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/notifications/AndroidNotificationScheduler.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app.business
+package com.mensinator.app.business.notifications
 
 import android.app.AlarmManager
 import android.app.PendingIntent

--- a/app/src/main/java/com/mensinator/app/business/notifications/IAndroidNotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/notifications/IAndroidNotificationScheduler.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app.business
+package com.mensinator.app.business.notifications
 
 import java.time.LocalDate
 

--- a/app/src/main/java/com/mensinator/app/business/notifications/INotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/notifications/INotificationScheduler.kt
@@ -1,4 +1,4 @@
-package com.mensinator.app.business
+package com.mensinator.app.business.notifications
 
 interface INotificationScheduler {
     /**

--- a/app/src/main/java/com/mensinator/app/business/notifications/NotificationScheduler.kt
+++ b/app/src/main/java/com/mensinator/app/business/notifications/NotificationScheduler.kt
@@ -1,8 +1,10 @@
-package com.mensinator.app.business
+package com.mensinator.app.business.notifications
 
 
 import android.content.Context
 import android.util.Log
+import com.mensinator.app.business.IPeriodDatabaseHelper
+import com.mensinator.app.business.IPeriodPrediction
 import com.mensinator.app.settings.IntSetting
 import com.mensinator.app.settings.StringSetting
 import com.mensinator.app.ui.ResourceMapper
@@ -23,13 +25,15 @@ class NotificationScheduler(
     private val androidNotificationScheduler: IAndroidNotificationScheduler,
 ) : INotificationScheduler {
 
+    private val defaultReminderDays = 2
+
     // Schedule notification for reminder
     // Check that reminders should be scheduled (reminder>0)
     // and that it's more then reminderDays left (do not schedule notifications where there's too few reminderDays left until period)
     override suspend fun schedulePeriodNotification() {
         withContext(dispatcherProvider.IO) {
             val periodReminderDays =
-                dbHelper.getSettingByKey(IntSetting.REMINDER_DAYS.settingDbKey)?.value?.toIntOrNull() ?: 2
+                dbHelper.getSettingByKey(IntSetting.REMINDER_DAYS.settingDbKey)?.value?.toIntOrNull() ?: defaultReminderDays
             val nextPeriodDate = periodPrediction.getPredictedPeriodDate()
             val initPeriodKeyOrCustomMessage =
                 dbHelper.getStringSettingByKey(StringSetting.PERIOD_NOTIFICATION_MESSAGE.settingDbKey)

--- a/app/src/main/java/com/mensinator/app/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/mensinator/app/calendar/CalendarViewModel.kt
@@ -4,7 +4,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.kizitonwose.calendar.core.yearMonth
-import com.mensinator.app.business.*
+import com.mensinator.app.business.IOvulationPrediction
+import com.mensinator.app.business.IPeriodDatabaseHelper
+import com.mensinator.app.business.IPeriodPrediction
+import com.mensinator.app.business.PeriodId
+import com.mensinator.app.business.notifications.INotificationScheduler
 import com.mensinator.app.data.ColorSource
 import com.mensinator.app.data.Symptom
 import com.mensinator.app.data.isActive

--- a/app/src/main/java/com/mensinator/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/mensinator/app/settings/SettingsViewModel.kt
@@ -1,17 +1,20 @@
 package com.mensinator.app.settings
 
 import android.annotation.SuppressLint
+import android.app.NotificationManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.util.Log
 import android.widget.Toast
 import androidx.compose.ui.graphics.Color
+import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.mensinator.app.NotificationChannelConstants
 import com.mensinator.app.R
 import com.mensinator.app.business.IExportImport
-import com.mensinator.app.business.INotificationScheduler
 import com.mensinator.app.business.IPeriodDatabaseHelper
+import com.mensinator.app.business.notifications.INotificationScheduler
 import com.mensinator.app.data.ColorSource
 import com.mensinator.app.settings.ColorSetting.*
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -36,7 +39,7 @@ class SettingsViewModel(
             expectedOvulationColor = Color.Yellow,
             openColorPickerForSetting = null,
 
-            daysBeforeReminder = -1,
+            daysBeforeReminder = "?",
             periodNotificationMessage = "",
             showPeriodNotificationDialog = false,
             daysForPeriodHistory = -1,
@@ -69,7 +72,7 @@ class SettingsViewModel(
         val expectedOvulationColor: Color,
         val openColorPickerForSetting: ColorSetting? = null,
 
-        val daysBeforeReminder: Int,
+        val daysBeforeReminder: String,
         val periodNotificationMessage: String,
         val showPeriodNotificationDialog: Boolean,
         val daysForPeriodHistory: Int,
@@ -94,6 +97,15 @@ class SettingsViewModel(
         refreshData()
     }
 
+    fun onResume() {
+        viewModelScope.launch {
+            // Make sure to display the correct text once the user came back from updating the settings
+            _viewState.update {
+                it.copy(daysBeforeReminder = getDaysBeforeReminderText())
+            }
+        }
+    }
+
     fun updateDarkModeStatus(isDarkMode: Boolean) {
         _viewState.update { it.copy(isDarkMode = isDarkMode) }
         refreshData()
@@ -110,7 +122,7 @@ class SettingsViewModel(
                     ovulationColor = getColor(isDarkMode, OVULATION.settingDbKey),
                     expectedOvulationColor = getColor(isDarkMode, EXPECTED_OVULATION.settingDbKey),
 
-                    daysBeforeReminder = getInt(IntSetting.REMINDER_DAYS.settingDbKey),
+                    daysBeforeReminder = getDaysBeforeReminderText(),
                     periodNotificationMessage = getString(StringSetting.PERIOD_NOTIFICATION_MESSAGE.settingDbKey),
                     daysForPeriodHistory = getInt(IntSetting.PERIOD_HISTORY.settingDbKey),
                     daysForOvulationHistory = getInt(IntSetting.OVULATION_HISTORY.settingDbKey),
@@ -123,11 +135,29 @@ class SettingsViewModel(
         }
     }
 
-    fun updateColorSetting(colorSetting: ColorSetting, newColorName: String) = viewModelScope.launch {
+    suspend fun getDaysBeforeReminderText(): String {
+        return if (!areNotificationsEnabled(appContext)) {
+            "?"
+        } else {
+            getInt(IntSetting.REMINDER_DAYS.settingDbKey).toString()
+        }
+    }
+
+    /**
+     * Check whether notifications are enabled and whether the notification channel is not deactivated
+     */
+    fun areNotificationsEnabled(context: Context): Boolean {
+        val notificationManager = NotificationManagerCompat.from(context)
+        val channel = notificationManager.getNotificationChannel(NotificationChannelConstants.channelId)
+        return channel?.importance != NotificationManager.IMPORTANCE_NONE && notificationManager.areNotificationsEnabled()
+    }
+
+    fun updateColorSetting(colorSetting: ColorSetting, newColorName: String) =
+        viewModelScope.launch {
             periodDatabaseHelper.updateSetting(colorSetting.settingDbKey, newColorName)
             showColorPicker(null)
             refreshData()
-    }
+        }
 
     fun updateIntSetting(intSetting: IntSetting, newNumber: Int) = viewModelScope.launch {
         periodDatabaseHelper.updateSetting(intSetting.settingDbKey, newNumber.toString())
@@ -139,7 +169,7 @@ class SettingsViewModel(
         }
     }
 
-    fun updateBooleanSetting(booleanSetting: BooleanSetting, newValue: Boolean)= viewModelScope.launch {
+    fun updateBooleanSetting(booleanSetting: BooleanSetting, newValue: Boolean) = viewModelScope.launch {
         val dbValue = if (newValue) "1" else "0"
         periodDatabaseHelper.updateSetting(booleanSetting.settingDbKey, dbValue)
         refreshData()
@@ -217,11 +247,12 @@ class SettingsViewModel(
 
     private suspend fun getInt(settingKey: String): Int {
         val int = periodDatabaseHelper.getSettingByKey(settingKey)?.value ?: "0"
-        return int.toIntOrNull() ?: 0
+        return int.toIntOrNull() ?: -1
     }
 
     private suspend fun getBoolean(booleanSetting: BooleanSetting): Boolean {
-        val dbValue = periodDatabaseHelper.getSettingByKey(booleanSetting.settingDbKey)?.value ?: "0"
+        val dbValue =
+            periodDatabaseHelper.getSettingByKey(booleanSetting.settingDbKey)?.value ?: "0"
         val value = dbValue == "1" //
         return value
     }

--- a/app/src/main/java/com/mensinator/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/mensinator/app/settings/SettingsViewModel.kt
@@ -10,6 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.mensinator.app.R
 import com.mensinator.app.business.IExportImport
+import com.mensinator.app.business.INotificationScheduler
 import com.mensinator.app.business.IPeriodDatabaseHelper
 import com.mensinator.app.data.ColorSource
 import com.mensinator.app.settings.ColorSetting.*
@@ -23,6 +24,7 @@ class SettingsViewModel(
     private val periodDatabaseHelper: IPeriodDatabaseHelper,
     @SuppressLint("StaticFieldLeak") private val appContext: Context,
     private val exportImport: IExportImport,
+    private val notificationScheduler: INotificationScheduler,
 ) : ViewModel() {
     private val _viewState = MutableStateFlow(
         ViewState(
@@ -121,25 +123,29 @@ class SettingsViewModel(
         }
     }
 
-    fun updateColorSetting(colorSetting: ColorSetting, newColorName: String) {
-        periodDatabaseHelper.updateSetting(colorSetting.settingDbKey, newColorName)
-        showColorPicker(null)
-        refreshData()
+    fun updateColorSetting(colorSetting: ColorSetting, newColorName: String) = viewModelScope.launch {
+            periodDatabaseHelper.updateSetting(colorSetting.settingDbKey, newColorName)
+            showColorPicker(null)
+            refreshData()
     }
 
-    fun updateIntSetting(intSetting: IntSetting, newNumber: Int) {
+    fun updateIntSetting(intSetting: IntSetting, newNumber: Int) = viewModelScope.launch {
         periodDatabaseHelper.updateSetting(intSetting.settingDbKey, newNumber.toString())
         showIntPicker(null)
         refreshData()
+
+        if (intSetting == IntSetting.REMINDER_DAYS) {
+            notificationScheduler.schedulePeriodNotification()
+        }
     }
 
-    fun updateBooleanSetting(booleanSetting: BooleanSetting, newValue: Boolean) {
+    fun updateBooleanSetting(booleanSetting: BooleanSetting, newValue: Boolean)= viewModelScope.launch {
         val dbValue = if (newValue) "1" else "0"
         periodDatabaseHelper.updateSetting(booleanSetting.settingDbKey, dbValue)
         refreshData()
     }
 
-    fun updateStringSetting(stringSetting: StringSetting, newString: String) {
+    fun updateStringSetting(stringSetting: StringSetting, newString: String) = viewModelScope.launch {
         periodDatabaseHelper.updateSetting(stringSetting.settingDbKey, newString)
         refreshData()
     }

--- a/app/src/main/java/com/mensinator/app/ui/ResourceMapper.kt
+++ b/app/src/main/java/com/mensinator/app/ui/ResourceMapper.kt
@@ -49,14 +49,18 @@ object ResourceMapper {
         return resourceMap[key]
     }
 
-    fun getStringResourceOrCustom(key: String, context: Context): String {
-        /**
-         * - If key is unchanged, return the stringResource value
-         * - If key has changed (null), return user-set value
-         */
-        val id = getStringResourceId(key)
-        val text = id?.let { context.getString(id) } ?: key
-        return text
+    fun getPeriodReminderMessage(key: String, context: Context): String {
+        // If we can't retrieve a resource ID via the key, we know that the user has changed the text.
+        val userHasChangedMessage = getStringResourceId(key) == null
+
+        val appDefaultText = context.getString(R.string.period_notification_message)
+        val userSetValue = key.takeIf { userHasChangedMessage }
+
+        return if (userSetValue.isNullOrBlank()) {
+            appDefaultText
+        } else {
+            userSetValue
+        }
     }
 
     @Composable

--- a/app/src/main/java/com/mensinator/app/utils/IDispatcherProvider.kt
+++ b/app/src/main/java/com/mensinator/app/utils/IDispatcherProvider.kt
@@ -1,10 +1,11 @@
 package com.mensinator.app.utils
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
 @Suppress("unused", "PropertyName")
 interface IDispatcherProvider {
-    val Main
+    val Main: CoroutineDispatcher
         get() = Dispatchers.Main
     val Default
         get() = Dispatchers.Default

--- a/app/src/main/java/com/mensinator/app/utils/IDispatcherProvider.kt
+++ b/app/src/main/java/com/mensinator/app/utils/IDispatcherProvider.kt
@@ -1,5 +1,17 @@
 package com.mensinator.app.utils
 
-interface DispatcherProvider {
-    
+import kotlinx.coroutines.Dispatchers
+
+@Suppress("unused", "PropertyName")
+interface IDispatcherProvider {
+    val Main
+        get() = Dispatchers.Main
+    val Default
+        get() = Dispatchers.Default
+    val IO
+        get() = Dispatchers.IO
+    val Unconfined
+        get() = Dispatchers.Unconfined
 }
+
+class DefaultDispatcherProvider : IDispatcherProvider

--- a/app/src/main/java/com/mensinator/app/utils/IDispatcherProvider.kt
+++ b/app/src/main/java/com/mensinator/app/utils/IDispatcherProvider.kt
@@ -1,0 +1,5 @@
+package com.mensinator.app.utils
+
+interface DispatcherProvider {
+    
+}

--- a/app/src/test/java/com/mensinator/app/business/NotificationSchedulerTest.kt
+++ b/app/src/test/java/com/mensinator/app/business/NotificationSchedulerTest.kt
@@ -1,0 +1,213 @@
+package com.mensinator.app.business
+
+import android.content.Context
+import com.mensinator.app.data.Setting
+import com.mensinator.app.settings.IntSetting
+import com.mensinator.app.settings.StringSetting
+import com.mensinator.app.ui.ResourceMapper
+import com.mensinator.app.utils.IDispatcherProvider
+import io.mockk.*
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.RelaxedMockK
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.time.LocalDate
+import java.time.ZoneOffset
+import java.util.TimeZone
+
+@ExperimentalCoroutinesApi
+@RunWith(JUnit4::class)
+class NotificationSchedulerTest {
+
+    @RelaxedMockK
+    private lateinit var context: Context
+
+    @MockK
+    private lateinit var dbHelper: IPeriodDatabaseHelper
+
+    @MockK
+    private lateinit var periodPrediction: IPeriodPrediction
+
+    @RelaxedMockK
+    private lateinit var androidNotificationScheduler: IAndroidNotificationScheduler
+
+    @MockK
+    private lateinit var dispatcherProvider: IDispatcherProvider
+
+    private lateinit var notificationScheduler: NotificationScheduler
+    private val testDispatcher = UnconfinedTestDispatcher()
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this)
+
+        every { dispatcherProvider.IO } returns testDispatcher
+        every { dispatcherProvider.Main } returns testDispatcher
+
+        notificationScheduler = NotificationScheduler(
+            context,
+            dbHelper,
+            periodPrediction,
+            dispatcherProvider,
+            androidNotificationScheduler
+        )
+
+        mockkObject(ResourceMapper)
+
+        TimeZone.setDefault(TimeZone.getTimeZone(ZoneOffset.UTC))
+    }
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    @Test
+    fun `schedule notification with valid parameters`() = runTest(testDispatcher) {
+        // Given
+        val reminderDays = 2
+        val today = LocalDate.now()
+        val predictedDate = today.plusDays(5)
+        val expectedNotificationDate = predictedDate.minusDays(reminderDays.toLong())
+        val customMessage = "Custom period message"
+        val mappedMessage = "Your period is coming in 2 days"
+
+        coEvery { dbHelper.getSettingByKey(IntSetting.REMINDER_DAYS.settingDbKey) } returns mockk<Setting> {
+            every { value } returns reminderDays.toString()
+        }
+        every { periodPrediction.getPredictedPeriodDate() } returns predictedDate
+        coEvery { dbHelper.getStringSettingByKey(StringSetting.PERIOD_NOTIFICATION_MESSAGE.settingDbKey) } returns customMessage
+        every {
+            ResourceMapper.getPeriodReminderMessage(customMessage, any())
+        } returns mappedMessage
+
+        // When
+        notificationScheduler.schedulePeriodNotification()
+
+        verify {
+            androidNotificationScheduler.scheduleNotification(
+                mappedMessage,
+                expectedNotificationDate
+            )
+        }
+    }
+
+    @Test
+    fun `do not schedule notification when reminder days is zero`() = runTest(testDispatcher) {
+        // Given
+        val reminderDays = 0
+        val predictedDate = LocalDate.now().plusDays(5)
+
+        coEvery { dbHelper.getSettingByKey(IntSetting.REMINDER_DAYS.settingDbKey) } returns mockk<Setting> {
+            every { value } returns reminderDays.toString()
+        }
+        every { periodPrediction.getPredictedPeriodDate() } returns predictedDate
+        coEvery { dbHelper.getStringSettingByKey(StringSetting.PERIOD_NOTIFICATION_MESSAGE.settingDbKey) } returns "message"
+        every { ResourceMapper.getPeriodReminderMessage(any(), any()) } returns "mapped message"
+
+        // When
+        notificationScheduler.schedulePeriodNotification()
+
+        // Then
+        verify { androidNotificationScheduler.cancelScheduledNotification() }
+    }
+
+    @Test
+    fun `do not schedule notification when reminder date is in the past`() = runTest(testDispatcher) {
+        // Given
+        val reminderDays = 3
+        val today = LocalDate.now()
+        val predictedDate = today.plusDays(2) // This makes the reminder date in the past
+
+        coEvery { dbHelper.getSettingByKey(IntSetting.REMINDER_DAYS.settingDbKey) } returns mockk<Setting> {
+            every { value } returns reminderDays.toString()
+        }
+        every { periodPrediction.getPredictedPeriodDate() } returns predictedDate
+        coEvery { dbHelper.getStringSettingByKey(StringSetting.PERIOD_NOTIFICATION_MESSAGE.settingDbKey) } returns "message"
+        every {
+            ResourceMapper.getPeriodReminderMessage(any(), any())
+        } returns "mapped message"
+
+        // When
+        notificationScheduler.schedulePeriodNotification()
+
+        // Then
+        verify { androidNotificationScheduler.cancelScheduledNotification() }
+    }
+
+    @Test
+    fun `do not schedule notification when predicted date is null`() = runTest(testDispatcher) {
+        // Given
+        val reminderDays = 2
+
+        coEvery { dbHelper.getSettingByKey(IntSetting.REMINDER_DAYS.settingDbKey) } returns mockk<Setting> {
+            every { value } returns reminderDays.toString()
+        }
+        every { periodPrediction.getPredictedPeriodDate() } returns null
+        coEvery { dbHelper.getStringSettingByKey(StringSetting.PERIOD_NOTIFICATION_MESSAGE.settingDbKey) } returns "message"
+        every { ResourceMapper.getPeriodReminderMessage(any(), any()) } returns "mapped message"
+
+        // When
+        notificationScheduler.schedulePeriodNotification()
+
+        // Then
+        verify { androidNotificationScheduler.cancelScheduledNotification() }
+    }
+
+    @Test
+    fun `use default reminder days when setting is null`() = runTest(testDispatcher) {
+        // Given
+        val defaultReminderDays = 2
+        val today = LocalDate.now()
+        val predictedDate = today.plusDays(5)
+        val expectedNotificationDate = predictedDate.minusDays(defaultReminderDays.toLong())
+        val message = "message"
+
+        coEvery { dbHelper.getSettingByKey(IntSetting.REMINDER_DAYS.settingDbKey) } returns null
+        every { periodPrediction.getPredictedPeriodDate() } returns predictedDate
+        coEvery { dbHelper.getStringSettingByKey(StringSetting.PERIOD_NOTIFICATION_MESSAGE.settingDbKey) } returns message
+        every { ResourceMapper.getPeriodReminderMessage(any(), any()) } returns message
+
+        // When
+        notificationScheduler.schedulePeriodNotification()
+
+        // Then
+        verify {
+            androidNotificationScheduler.scheduleNotification(message, expectedNotificationDate)
+        }
+    }
+
+    @Test
+    fun `use default reminder days when setting is not a number`() = runTest(testDispatcher) {
+        // Given
+        val defaultReminderDays = 2
+        val today = LocalDate.now()
+        val predictedDate = today.plusDays(5)
+        val expectedNotificationDate = predictedDate.minusDays(defaultReminderDays.toLong())
+        val message = "message"
+
+        coEvery { dbHelper.getSettingByKey(IntSetting.REMINDER_DAYS.settingDbKey) } returns mockk<Setting> {
+            every { value } returns "not a number"
+        }
+        every { periodPrediction.getPredictedPeriodDate() } returns predictedDate
+        coEvery { dbHelper.getStringSettingByKey(StringSetting.PERIOD_NOTIFICATION_MESSAGE.settingDbKey) } returns message
+        every { ResourceMapper.getPeriodReminderMessage(any(), any()) } returns message
+
+        // When
+        notificationScheduler.schedulePeriodNotification()
+
+        // Then
+        verify {
+            androidNotificationScheduler.scheduleNotification(
+                message,
+                expectedNotificationDate
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/mensinator/app/business/NotificationSchedulerTest.kt
+++ b/app/src/test/java/com/mensinator/app/business/NotificationSchedulerTest.kt
@@ -1,6 +1,8 @@
 package com.mensinator.app.business
 
 import android.content.Context
+import com.mensinator.app.business.notifications.IAndroidNotificationScheduler
+import com.mensinator.app.business.notifications.NotificationScheduler
 import com.mensinator.app.data.Setting
 import com.mensinator.app.settings.IntSetting
 import com.mensinator.app.settings.StringSetting

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ kizitonwoseCalendar = "2.6.2"
 mockk = "1.13.17"
 material3 = "1.3.1"
 material3-adaptive = "1.1.0"
-coroutines = "1.3.9"
+coroutines = "1.10.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ kizitonwoseCalendar = "2.6.2"
 mockk = "1.13.17"
 material3 = "1.3.1"
 material3-adaptive = "1.1.0"
+coroutines = "1.3.9"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core" }
@@ -48,6 +49,8 @@ androidx-navigation-common-ktx = { group = "androidx.navigation", name = "naviga
 koin = { group = "io.insert-koin", name = "koin-android" }
 koin-compose = { group = "io.insert-koin", name = "koin-androidx-compose" }
 koin-bom = { group = "io.insert-koin", name = "koin-bom", version.ref = "koinBom" }
+kotlinx-coroutines = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "coroutines" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 
 [plugins]


### PR DESCRIPTION
* Scheduled Notifications are now cancelled in case the period prediction no longer exists or the other conditions no longer apply. Fixes #216
* The "Reminder before days" setting now shows "?" when the notification permission was not granted yet or the channel is blocked. Fixes #215
* Tapping on the notifications now open the app.

Tasks:
- [x] Write unit tests for `NotificationScheduler`
- [x] Check if the notification title should be removed or exchanged by "Period Reminder" or something like that - Decision: Just remove the hardcoded text