### PR TITLE
[Offering] Functionality to import data from "My Calendar"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Puru-Mensinator ✨
+**⚠ This is my fork of Mensinator to adapt it to my needs. To get the real deal, [please go to the original repo!](https://github.com/EmmaTellblom/Mensinator)**
+
+↓ Check out a summary of the original app below, from their own readme ↓
+
+-------------
+
 # Mensinator🩸
 Private period tracking with custom symptoms. We don't track your data - you do. Period.
 
@@ -14,27 +21,6 @@ Private period tracking with custom symptoms. We don't track your data - you do.
 Originally, Emma made Mensinator for a friend who was looking for an app that would track unique period symptoms and respect her privacy.
 Soon, more like-minded individuals joined the project. 
 We all wanted a user-friendly, straigtforward app made for us, not an app that uses our data for profit. We are now actively building Mensinator together. 
-
-## 🔮 Future plans
-- Whatever you suggest! Discuss ideas with users and developers on **[our Discord](https://discord.gg/tHA2k3bFRN)**. Let us know what features you'd like to see.
-
-## 🤝 Active development and user community
-Join **[our Discord](https://discord.gg/tHA2k3bFRN)** to share your thoughts, ask questions, and chat with other users and our team.  
-Mensinator is in early development, made by people like you. Your feedback helps us continue improving it.  
-Share a quick thought, or stick around to nag the developers to make the app into what you want it to be. You can even help by developing the features directly.
-
-## 💾 Get the app
-Download the Mensinator app from your preferred source:
-- **[F-Droid](https://f-droid.org/en/packages/com.mensinator.app/)** (free and open-source app store)
-- **[Google Play](https://play.google.com/store/apps/details?id=com.mensinator.app)** (Google's app store)
-- **[IzzyOnDroid](https://apt.izzysoft.de/fdroid/index/apk/com.mensinator.app)** (an F-Droid repository)
-- **[latest release on GitHub](https://github.com/EmmaTellblom/Mensinator/releases/latest)** (NO automatic updates)
-
-## 🛠️ Contributing for developers
-We welcome contributions to improve Mensinator!  
-If you'd like to contribute, please **[fork the repository](https://github.com/EmmaTellblom/Mensinator/fork)** and submit a pull request.  
-For major changes, please **[open an issue](https://github.com/EmmaTellblom/Mensinator/issues/new/choose)** first to discuss your proposed changes.  
-You are also welcome to **[join our Discord](https://discord.gg/tHA2k3bFRN)** to discuss further or simply to chat with us!
 
 ## 📜 License
 This project is licensed under the **[MIT License](https://github.com/EmmaTellblom/Mensinator/blob/main/LICENSE)**.  

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-# Puru-Mensinator ✨
-**⚠ This is my fork of Mensinator to adapt it to my needs. To get the real deal, [please go to the original repo!](https://github.com/EmmaTellblom/Mensinator)**
-
-↓ Check out a summary of the original app below, from their own readme ↓
-
--------------
-
 # Mensinator🩸
 Private period tracking with custom symptoms. We don't track your data - you do. Period.
 
@@ -21,6 +14,27 @@ Private period tracking with custom symptoms. We don't track your data - you do.
 Originally, Emma made Mensinator for a friend who was looking for an app that would track unique period symptoms and respect her privacy.
 Soon, more like-minded individuals joined the project. 
 We all wanted a user-friendly, straigtforward app made for us, not an app that uses our data for profit. We are now actively building Mensinator together. 
+
+## 🔮 Future plans
+- Whatever you suggest! Discuss ideas with users and developers on **[our Discord](https://discord.gg/tHA2k3bFRN)**. Let us know what features you'd like to see.
+
+## 🤝 Active development and user community
+Join **[our Discord](https://discord.gg/tHA2k3bFRN)** to share your thoughts, ask questions, and chat with other users and our team.  
+Mensinator is in early development, made by people like you. Your feedback helps us continue improving it.  
+Share a quick thought, or stick around to nag the developers to make the app into what you want it to be. You can even help by developing the features directly.
+
+## 💾 Get the app
+Download the Mensinator app from your preferred source:
+- **[F-Droid](https://f-droid.org/en/packages/com.mensinator.app/)** (free and open-source app store)
+- **[Google Play](https://play.google.com/store/apps/details?id=com.mensinator.app)** (Google's app store)
+- **[IzzyOnDroid](https://apt.izzysoft.de/fdroid/index/apk/com.mensinator.app)** (an F-Droid repository)
+- **[latest release on GitHub](https://github.com/EmmaTellblom/Mensinator/releases/latest)** (NO automatic updates)
+
+## 🛠️ Contributing for developers
+We welcome contributions to improve Mensinator!  
+If you'd like to contribute, please **[fork the repository](https://github.com/EmmaTellblom/Mensinator/fork)** and submit a pull request.  
+For major changes, please **[open an issue](https://github.com/EmmaTellblom/Mensinator/issues/new/choose)** first to discuss your proposed changes.  
+You are also welcome to **[join our Discord](https://discord.gg/tHA2k3bFRN)** to discuss further or simply to chat with us!
 
 ## 📜 License
 This project is licensed under the **[MIT License](https://github.com/EmmaTellblom/Mensinator/blob/main/LICENSE)**.  


### PR DESCRIPTION
**_Related to enhancement #140 "Support of importing data from other apps"_**

I made a function to import data from ["My Calendar" / "Period Calendar"](https://play.google.com/store/apps/details?id=com.popularapp.periodcalendar) (I don't know what's its name in English...). I thought that you might be interested in taking a look at it. The function is by no means ready for your scope right now, as it only imports from files that are written in Spanish because I made it for myself. But I think that it wouldn't be hard to broaden the languages that it supports by adding some Lists.

"My Calendar" makes backups in a  `.pc` file extension that I haven't found how to read correctly. The only way to get readable data is with the "Export data for your doctor" option, that generates a `.txt`. In function `transformMyCalendarFormatToMensinatorFormat()` I read the `.txt` and transform it into a JSON that follows Mensinator's way of structuring data. Then it is imported normally.