### PR TITLE
docs: Fastlane: full_description.txt remove unnecessary sections

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -16,9 +16,5 @@
 </ul>
 <h4>Who Should Use It?</h4>
 <p>Mensinator is perfect for anyone seeking a straightforward and private period tracking solution. Whether you're tracking for health reasons or simply keeping an eye on your cycle, Mensinator makes it easy and secure.</p>
-<h4>Getting Started</h4>
-<p>To get started with Mensinator, you can either get it from <a href="https://apt.izzysoft.de/packages/com.mensinator.app">IzzyOnDroid</a> or from <a href="https://play.google.com/store/apps/details?id=com.mensinator.app">GooglePlay</a> and start tracking your menstrual cycle with ease and privacy.</p>
-<p></p>
 <h4>Contributing</h4>We welcome contributions to improve Mensinator! If you'd like to contribute, please fork the repository and submit a pull request. For major changes, please open an issue first to discuss your proposed changes. You are also welcome to join <a href="https://discord.gg/tHA2k3bFRN">our Discord</a> to discuss further or simply to chat with us!</p>
-<h4>License</h4>
-<p>This project is licensed under the MIT License - see the LICENSE file for details.</p>
+

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,8 +1,8 @@
-<h4>Mensinator</h4>
+<b>Mensinator</b>
 Mensinator is the ultimate period tracker designed for those who prioritize simplicity, privacy, and user-friendliness. 🌟
 <h4>Overview</h4>
 Mensinator provides a clean and intuitive interface for tracking your menstrual cycle, monitoring your periods, and viewing essential statistics—all without the need for sign-ups or sharing personal data. All information is stored securely on your device, ensuring your privacy is always protected. 🛡️
-<h4>Key Features</h4>
+<b>Key Features</b>
 <ul>
 <li>Effortless Period Tracking: Easily mark your periods, view your cycle, and access statistics all in one place. 📅</li>
 <li>No Sign-Up Required: Start using the app immediately—no account creation or personal information required. 🎉</li>
@@ -14,8 +14,8 @@ Mensinator provides a clean and intuitive interface for tracking your menstrual 
 <li>Customizable Colors: Personalize the app's appearance by customizing colors to your preference. 🎨</li>
 <li>Export and Import Data: Easily export your data to a JSON file for backup or transfer and import it back into the app whenever needed. 📂</li>
 </ul>
-<h4>Who Should Use It?</h4>
+<b>Who Should Use It?</b>
 Mensinator is perfect for anyone seeking a straightforward and private period tracking solution. Whether you're tracking for health reasons or simply keeping an eye on your cycle, Mensinator makes it easy and secure.
-<h4>Contributing</h4>
+<b>Contributing</b>
 We welcome contributions to improve Mensinator! If you'd like to contribute, please fork the repository and submit a pull request. For major changes, please open an issue first to discuss your proposed changes. You are also welcome to join <a href="https://discord.gg/tHA2k3bFRN">our Discord</a> to discuss further or simply to chat with us!
 

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,7 +1,7 @@
 <h4>Mensinator</h4>
-<p>Mensinator is the ultimate period tracker designed for those who prioritize simplicity, privacy, and user-friendliness. 🌟</p>
+Mensinator is the ultimate period tracker designed for those who prioritize simplicity, privacy, and user-friendliness. 🌟
 <h4>Overview</h4>
-<p>Mensinator provides a clean and intuitive interface for tracking your menstrual cycle, monitoring your periods, and viewing essential statistics—all without the need for sign-ups or sharing personal data. All information is stored securely on your device, ensuring your privacy is always protected. 🛡️</p>
+Mensinator provides a clean and intuitive interface for tracking your menstrual cycle, monitoring your periods, and viewing essential statistics—all without the need for sign-ups or sharing personal data. All information is stored securely on your device, ensuring your privacy is always protected. 🛡️
 <h4>Key Features</h4>
 <ul>
 <li>Effortless Period Tracking: Easily mark your periods, view your cycle, and access statistics all in one place. 📅</li>
@@ -15,6 +15,7 @@
 <li>Export and Import Data: Easily export your data to a JSON file for backup or transfer and import it back into the app whenever needed. 📂</li>
 </ul>
 <h4>Who Should Use It?</h4>
-<p>Mensinator is perfect for anyone seeking a straightforward and private period tracking solution. Whether you're tracking for health reasons or simply keeping an eye on your cycle, Mensinator makes it easy and secure.</p>
-<h4>Contributing</h4>We welcome contributions to improve Mensinator! If you'd like to contribute, please fork the repository and submit a pull request. For major changes, please open an issue first to discuss your proposed changes. You are also welcome to join <a href="https://discord.gg/tHA2k3bFRN">our Discord</a> to discuss further or simply to chat with us!</p>
+Mensinator is perfect for anyone seeking a straightforward and private period tracking solution. Whether you're tracking for health reasons or simply keeping an eye on your cycle, Mensinator makes it easy and secure.
+<h4>Contributing</h4>
+We welcome contributions to improve Mensinator! If you'd like to contribute, please fork the repository and submit a pull request. For major changes, please open an issue first to discuss your proposed changes. You are also welcome to join <a href="https://discord.gg/tHA2k3bFRN">our Discord</a> to discuss further or simply to chat with us!
 


### PR DESCRIPTION
Users don't need to know links to GooglePlay or IzzyOnAdroid (BTW F-Droid is missing). They are already reading the description in the app store.
The License section is also not that important and can be seen in the repository.

I also removed the `<p>` tag that is not well supported and also replaced the `<h4>` tag that may not be supported with `<b>` that is definitely supported.