### PR TITLE
Added luteal warning dialog issue #251

### DIFF
--- a/app/src/main/java/com/mensinator/app/settings/LutealWarningDialog.kt
+++ b/app/src/main/java/com/mensinator/app/settings/LutealWarningDialog.kt
@@ -1,0 +1,45 @@
+package com.mensinator.app.settings
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import com.mensinator.app.R
+import com.mensinator.app.ui.theme.MensinatorTheme
+
+
+@Composable
+fun LutealWarningDialog(
+    onDismissRequest: () -> Unit, // Callback to handle the close action
+    modifier: Modifier = Modifier
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,  // Call the dismiss callback when dialog is dismissed
+        confirmButton = {
+            Button(
+                onClick = onDismissRequest  // Call the dismiss callback when the button is clicked
+            ) {
+                Text(stringResource(id = R.string.close_button))
+            }
+        },
+        modifier = modifier.fillMaxWidth(),
+        title = {
+            Text(text = stringResource(id = R.string.warning))
+        },
+        text = {
+            Text(text = stringResource(id = R.string.luteal_calculation_message))
+        },
+    )
+}
+
+@Preview
+@Composable
+private fun LutealDialogWarningPreview() {
+    MensinatorTheme {
+        LutealWarningDialog(onDismissRequest = {})
+    }
+}

--- a/app/src/main/java/com/mensinator/app/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/mensinator/app/settings/SettingsScreen.kt
@@ -119,6 +119,7 @@ fun SettingsScreen(
             checked = viewState.lutealPhaseCalculationEnabled,
             onCheckedChange = {
                 viewModel.updateBooleanSetting(BooleanSetting.LUTEAL_PHASE_CALCULATION, it)
+                viewModel.showLutealWarningDialog(it)
             }
         )
         SettingNumberSelection(
@@ -178,6 +179,10 @@ fun SettingsScreen(
                     viewModel.handleImport(importPath)
                 }
             )
+        }
+
+        if(viewState.showLutealWarningDialog){
+            LutealWarningDialog(onDismissRequest = { viewModel.showLutealWarningDialog(false) })
         }
 
         if (viewState.showExportDialog) {
@@ -251,16 +256,6 @@ private fun ColorSection(
         },
         onOpenColorPicker = { viewModel.showColorPicker(it) },
     )
-//    SettingColorSelection(
-//        colorSetting = ColorSetting.PERIOD_SELECTION,
-//        currentColor = viewState.periodSelectionColor,
-//        openColorPickerForSetting = viewState.openColorPickerForSetting,
-//        onClosePicker = { viewModel.showColorPicker(null) },
-//        onColorChange = { colorSetting, newColor ->
-//            viewModel.updateColorSetting(colorSetting, newColor)
-//        },
-//        onOpenColorPicker = { viewModel.showColorPicker(it) },
-//    )
     SettingColorSelection(
         colorSetting = ColorSetting.EXPECTED_PERIOD,
         currentColor = viewState.expectedPeriodColor,
@@ -637,4 +632,3 @@ private fun NewScreenPreview() {
         SettingsScreen(onSwitchProtectionScreen = {})
     }
 }
-

--- a/app/src/main/java/com/mensinator/app/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/mensinator/app/settings/SettingsScreen.kt
@@ -167,6 +167,10 @@ fun SettingsScreen(
         AboutSection(viewModel, viewState)
         Spacer(Modifier.height(16.dp))
 
+        if (viewState.showLutealWarningDialog) {
+            LutealWarningDialog(onDismissRequest = { viewModel.showLutealWarningDialog(false) })
+        }
+
         if (viewState.showFaqDialog) {
             FaqDialog(onDismissRequest = { viewModel.showFaqDialog(false) })
         }
@@ -179,10 +183,6 @@ fun SettingsScreen(
                     viewModel.handleImport(importPath)
                 }
             )
-        }
-
-        if(viewState.showLutealWarningDialog){
-            LutealWarningDialog(onDismissRequest = { viewModel.showLutealWarningDialog(false) })
         }
 
         if (viewState.showExportDialog) {

--- a/app/src/main/java/com/mensinator/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/mensinator/app/settings/SettingsViewModel.kt
@@ -55,8 +55,9 @@ class SettingsViewModel(
             showExportDialog = false,
             defaultImportFilePath = exportImport.getDefaultImportFilePath(),
 
-            showFaqDialog = false,
             showLutealWarningDialog = false,
+            showFaqDialog = false,
+
             appVersion = getAppVersion(appContext),
             dbVersion = periodDatabaseHelper.getDBVersion(),
         )

--- a/app/src/main/java/com/mensinator/app/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/mensinator/app/settings/SettingsViewModel.kt
@@ -56,6 +56,7 @@ class SettingsViewModel(
             defaultImportFilePath = exportImport.getDefaultImportFilePath(),
 
             showFaqDialog = false,
+            showLutealWarningDialog = false,
             appVersion = getAppVersion(appContext),
             dbVersion = periodDatabaseHelper.getDBVersion(),
         )
@@ -86,6 +87,8 @@ class SettingsViewModel(
         val showImportDialog: Boolean,
         val showExportDialog: Boolean,
         val defaultImportFilePath: String,
+
+        val showLutealWarningDialog: Boolean,
 
         val showFaqDialog: Boolean,
         val appVersion: String,
@@ -235,6 +238,10 @@ class SettingsViewModel(
             showToast("Error during export: ${e.message}")
             Log.e("Export", "Error during export", e)
         }
+    }
+
+    fun showLutealWarningDialog(show: Boolean) {
+        _viewState.update { it.copy(showLutealWarningDialog = show) }
     }
 
     private suspend fun getColor(isDarkMode: Boolean, settingKey: String): Color {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,7 +61,8 @@
     <string name="warning">Warning</string>
     <string name="luteal_calculation_message">This calculation will use your number of luteal days (days from ovulation to period) to predict your next period.
         In order for this to work you need to track your ovulation in the app and have at least three ovulations in the history.
-        If you are unsure about this setting, turn it off. If the criteria are not meet, the prediction will not work</string>
+        If you are unsure about this setting, turn it off. If the criteria are not meet, the prediction will not work.
+        This calculation is good if you have irregular ovulations but fairly regular number of luteal days.</string>
     
     <!-- Color values -->
     <string name="color_red">Red</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,10 +59,13 @@
     <string name="close">Close</string>
     <string name="save">Save</string>
     <string name="warning">Warning</string>
-    <string name="luteal_calculation_message">This calculation will use your number of luteal days (days from ovulation to period) to predict your next period.
-        In order for this to work you need to track your ovulation in the app and have at least three ovulations in the history.
-        If you are unsure about this setting, turn it off. If the criteria are not meet, the prediction will not work.
-        This calculation is good if you have irregular ovulations but fairly regular number of luteal days.</string>
+    <string name="luteal_calculation_message">
+    This calculation will use your number of luteal days (days from ovulation to period) to predict your next period.\n
+    In order for this to work, you need to track your ovulations in the app and have at least three ovulations in the history.\n
+    If you are unsure about this setting, turn it off or join our Discord server to ask for help.\n
+    If the criteria are not met, the prediction will not work.\n
+    This calculation is good if you have irregular ovulations but a fairly regular number of luteal days.
+    </string>
     
     <!-- Color values -->
     <string name="color_red">Red</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -59,12 +59,7 @@
     <string name="close">Close</string>
     <string name="save">Save</string>
     <string name="warning">Warning</string>
-    <string name="luteal_calculation_message">
-    This calculation will use your number of luteal days (days from ovulation to period) to predict your next period.\n
-    In order for this to work, you need to track your ovulations in the app and have at least three ovulations in the history.\n
-    If you are unsure about this setting, turn it off or join our Discord server to ask for help.\n
-    If the criteria are not met, the prediction will not work.\n
-    This calculation is good if you have irregular ovulations but a fairly regular number of luteal days.
+    <string name="luteal_calculation_message">This calculation will use your number of luteal days (days from ovulation to period) to predict your next period.\nIn order for this to work, you need to track your ovulations in the app and have at least three ovulations in the history.\nIf you are unsure about this setting, turn it off or join our Discord server to ask for help.\nIf the criteria are not met, the prediction will not work.\nThis calculation is good if you have irregular ovulations but a fairly regular number of luteal days.
     </string>
     
     <!-- Color values -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -58,6 +58,10 @@
     <string name="screen_protection">Prevent Screenshots</string>
     <string name="close">Close</string>
     <string name="save">Save</string>
+    <string name="warning">Warning</string>
+    <string name="luteal_calculation_message">This calculation will use your number of luteal days (days from ovulation to period) to predict your next period.
+        In order for this to work you need to track your ovulation in the app and have at least three ovulations in the history.
+        If you are unsure about this setting, turn it off. If the criteria are not meet, the prediction will not work</string>
     
     <!-- Color values -->
     <string name="color_red">Red</string>


### PR DESCRIPTION
Added a dialog when activating luteal calculations to inform the users about what it means. 
![image](https://github.com/user-attachments/assets/04b34b71-eab0-4319-be41-c7445c3b4b62)

This shows up when the user turns on the luteal calculation toggle, just to explain what it actually does. Some users have enabled it without having ovulation data, which ends up removing future predictions.