### PR TITLE
Make flow symptoms more visible by adjusting color #279

### DIFF
--- a/app/src/main/java/com/mensinator/app/business/DatabaseUtils.kt
+++ b/app/src/main/java/com/mensinator/app/business/DatabaseUtils.kt
@@ -155,13 +155,13 @@ object DatabaseUtils {
         """)
         // Set all colors for the standard symptoms
         db.execSQL("""
-            UPDATE symptoms SET color = 'DarkRed' where symptom_name = 'Heavy_Flow'
+            UPDATE symptoms SET color = 'DarkPink' where symptom_name = 'Heavy_Flow'
         """)
         db.execSQL("""
-            UPDATE symptoms SET color = 'Red' where symptom_name = 'Medium_Flow'
+            UPDATE symptoms SET color = 'Pink' where symptom_name = 'Medium_Flow'
         """)
         db.execSQL("""
-            UPDATE symptoms SET color = 'LightRed' where symptom_name = 'Light_Flow'
+            UPDATE symptoms SET color = 'LightPink' where symptom_name = 'Light_Flow'
         """)
 
         // Fixed symptom colors, so we can remove setting for symptom indicator

--- a/app/src/main/java/com/mensinator/app/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/mensinator/app/calendar/CalendarScreen.kt
@@ -414,12 +414,13 @@ fun Day(
                 ) {
                     symptomsForDay.forEach { symptom ->
                         val symptomColor = state.calendarColors.symptomColors[symptom] ?: Color.Red
-
+                        var circleBorder = Color.White
+                        if(isDarkMode()) { circleBorder = Color.Black }
                         Box(
                             modifier = Modifier
                                 .size(11.dp)
                                 .background(symptomColor, CircleShape)
-                                .border(1.dp, Color.LightGray.copy(alpha = 0.25f), CircleShape)
+                                .border(1.dp, circleBorder, CircleShape)
                         )
                     }
                 }

--- a/app/src/main/java/com/mensinator/app/data/ColorSource.kt
+++ b/app/src/main/java/com/mensinator/app/data/ColorSource.kt
@@ -23,7 +23,8 @@ object ColorSource {
         listOf("LightCyan", "Cyan", "DarkCyan"),    // Cyan shades
         listOf("LightBlue", "Blue", "DarkBlue"),    // Blue shades
         listOf("LightMagenta", "Magenta", "DarkMagenta"), // Magenta shades
-        listOf("White", "LightGray", "DarkGray")    // Gray and Black shades
+        listOf("LightPink", "Pink", "DarkPink"),  // Pink Shades
+        listOf("LightGray", "DarkGray", "WhiteBlack")   // Gray, White and Black shades
     )
 
     private val lightColorMap = mapOf(
@@ -55,8 +56,8 @@ object ColorSource {
         "Orange" to Color(0xFFF2CBA6),
         "DarkOrange" to Color(0xFFF0B175),
 
-        "Black" to Color(0xFF212121),
         "DarkGray" to Color(0xFFABABAB),
+        "WhiteBlack" to Color(0xFF212121),
         "LightGray" to Color(0xFFDFDDDD),
 
         "LightPink" to Color(0xFFCC95BB),
@@ -93,8 +94,8 @@ object ColorSource {
         "Orange" to Color(0xFFB37E4D),
         "DarkOrange" to Color(0xFF6B4B2E),
 
-        "White" to Color(0xFFF5F5F5),
         "DarkGray" to Color(0xFF585858),
+        "WhiteBlack" to Color(0xFFF5F5F5),
         "LightGray" to Color(0xFF8F8F8F),
 
         "LightPink" to Color(0xFFCC95BB),

--- a/app/src/main/java/com/mensinator/app/data/ColorSource.kt
+++ b/app/src/main/java/com/mensinator/app/data/ColorSource.kt
@@ -58,6 +58,10 @@ object ColorSource {
         "Black" to Color(0xFF212121),
         "DarkGray" to Color(0xFFABABAB),
         "LightGray" to Color(0xFFDFDDDD),
+
+        "LightPink" to Color(0xFFCC95BB),
+        "Pink" to Color(0xFFB36098),
+        "DarkPink" to Color(0xFF7E3366)
     )
 
     private val darkColorMap = mapOf(
@@ -91,6 +95,10 @@ object ColorSource {
 
         "White" to Color(0xFFF5F5F5),
         "DarkGray" to Color(0xFF585858),
-        "LightGray" to Color(0xFF8F8F8F)
+        "LightGray" to Color(0xFF8F8F8F),
+
+        "LightPink" to Color(0xFFCC95BB),
+        "Pink" to Color(0xFFB36098),
+        "DarkPink" to Color(0xFF7E3366)
     )
 }

--- a/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
+++ b/app/src/main/java/com/mensinator/app/symptoms/ManageSymptomScreen.kt
@@ -256,7 +256,7 @@ private fun SymptomItemPreview() {
     MensinatorTheme {
         SymptomItem(
             onAction = {},
-            symptom = Symptom(1, "Medium flow", 1, "Red"),
+            symptom = Symptom(1, "Medium flow", 1, "Pink"),
             showDeletionIcon = true,
             modifier = Modifier.padding(8.dp)
         )


### PR DESCRIPTION
Made flow symptoms visible by adding new pink color hues
Dark mode hex codes for the new pinks:
Light pink: CC95BB
Medium pink: B36098
Dark pink: 7E3366

I used the same color for both light and dark mode, as requested in the mockup. 
Also, the symptom circles have outlines on the outside so that they are more visible.
On light mode, that color will be hex FFF6FF. On dark mode, that color will be hex 1E191F.

Related to the issue : https://github.com/EmmaTellblom/Mensinator/issues/279